### PR TITLE
feat: 自动关闭客户端，以及修复从睡眠中自动启动

### DIFF
--- a/MAAHelper/MAAHelper.swift
+++ b/MAAHelper/MAAHelper.swift
@@ -30,4 +30,9 @@ class MAAHelper: NSObject, MAAHelperProtocol {
             }
         }
     }
+    
+    @objc func terminateGame(processIdentifier: Int32) {
+        // NSWorkspace.shared.runningApplications is not updated in this helper when arknights is closed and opened again, can't figure out why so I have to get pid in main process and kill with pid in the helper
+        kill(processIdentifier, SIGTERM)
+    }
 }

--- a/MAAHelper/MAAHelperProtocol.swift
+++ b/MAAHelper/MAAHelperProtocol.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+import AppKit
 
 @objc protocol MAAHelperProtocol {
     func startGame(bundleName: String, with reply: @escaping (Bool) -> Void)
+    func terminateGame(processIdentifier: Int32)
 }

--- a/MeoAsstMac/Core/MaaMessage.swift
+++ b/MeoAsstMac/Core/MaaMessage.swift
@@ -159,9 +159,9 @@ extension MAAViewModel {
             break
 
         case .AllTasksCompleted:
+            actionAfterComplete()
             resetStatus()
-            logTrace("AllTasksComplete")
-
+            
         default:
             break
         }

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -21,6 +21,7 @@ import SwiftUI
 
     @Published private(set) var status = Status.idle
 
+    private var wakeupAssertionID: UInt32?
     private var awakeAssertionID: UInt32?
     private var handle: MAAHandle?
     private var cancellables = Set<AnyCancellable>()
@@ -489,15 +490,28 @@ extension MAAViewModel {
     func switchAwakeGuard(_ newValue: Status) {
         switch newValue {
         case .busy, .pending:
+            wakeupSystem()
             enableAwake()
         case .idle:
             disableAwake()
         }
     }
+    
+    // wakes the system from asleep
+    private func wakeupSystem() {
+        guard wakeupAssertionID == nil else { return }
+        var assertionID : IOPMAssertionID = 0
+        let name = "MAA is starting up, waking up the system"
+        let result = IOPMAssertionDeclareUserActivity(name as CFString, kIOPMUserActiveLocal, &assertionID)
+        if result == kIOReturnSuccess {
+            wakeupAssertionID = assertionID
+        }
+    }
 
+    // keeps the system from sleeping during tasks
     private func enableAwake() {
         guard awakeAssertionID == nil else { return }
-        var assertionID: UInt32 = 0
+        var assertionID: IOPMAssertionID = 0
         let name = "MAA is running; sleep is diabled."
         let properties = [kIOPMAssertionTypeKey: kIOPMAssertionTypeNoDisplaySleep as CFString,
                           kIOPMAssertionNameKey: name as CFString,
@@ -510,8 +524,11 @@ extension MAAViewModel {
 
     private func disableAwake() {
         guard let awakeAssertionID else { return }
+        guard let wakeupAssertionID else { return }
         IOPMAssertionRelease(awakeAssertionID)
+        IOPMAssertionRelease(wakeupAssertionID)
         self.awakeAssertionID = nil
+        self.wakeupAssertionID = nil
     }
 }
 

--- a/MeoAsstMac/Settings/GameSettingsView.swift
+++ b/MeoAsstMac/Settings/GameSettingsView.swift
@@ -17,6 +17,11 @@ struct GameSettingsView: View {
                     Text("\(channel.description)").tag(channel)
                 }
             }
+            Picker("完成后：", selection: $viewModel.actionsAfterComplete) {
+                ForEach(MAAViewModel.ActionsAfterComplete.allCases, id: \.self) {
+                    choice in Text(choice.rawValue).tag(choice)
+                }
+            }
         }
         .padding()
     }
@@ -24,6 +29,6 @@ struct GameSettingsView: View {
 
 struct GameSettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        GameSettingsView()
+        GameSettingsView().environmentObject(MAAViewModel())
     }
 }


### PR DESCRIPTION
简单修了一下尝试使用mac mini来24小时挂机时出现的问题，我也不是很懂swift，可能不是最好的方案

一是任务全部完成后自动关闭客户端，目前只针对playcover安装的原生客户端
二是自动关闭显示器后定时任务自动启动客户端时导致客户端崩溃，通过启动任务链时额外增加一个IOPMAssertionDeclareUserActivity的来唤醒系统解决