### PR TITLE
feat: ConfigurationView 启用预览，添加连战次数选框，启用企鹅物流

### DIFF
--- a/MeoAsstMac/Configuration Views/FightSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/FightSettingsView.swift
@@ -55,6 +55,10 @@ struct FightSettingsView: View {
                     Toggle("指定次数", isOn: limitBattles)
                 }
 
+                TextField(value: config.series, format: .number) {
+                    Toggle("连战次数", isOn: seriesBattles)
+                }
+
                 Picker(selection: .constant(0)) {
                     // TODO: stage
                 } label: {
@@ -106,6 +110,14 @@ struct FightSettingsView: View {
             config.times.wrappedValue != nil
         } set: {
             config.times.wrappedValue = $0 ? 5 : nil
+        }
+    }
+
+    private var seriesBattles: Binding<Bool> {
+        Binding {
+            config.series.wrappedValue != nil
+        } set: {
+            config.series.wrappedValue = $0 ? 1 : nil
         }
     }
 

--- a/MeoAsstMac/Configuration Views/FightSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/FightSettingsView.swift
@@ -76,7 +76,9 @@ struct FightSettingsView: View {
 
             Divider()
 
-            TextField("企鹅物流ID", text: .constant(""))
+            TextField(text: config.penguin_id) {
+                Toggle("企鹅物流汇报ID", isOn: config.report_to_penguin)
+            }
         }
         .padding()
     }

--- a/MeoAsstMac/Configuration Views/FightSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/FightSettingsView.swift
@@ -124,9 +124,9 @@ struct FightSettingsView: View {
     private let listedStages = ["", "1-7", "CE-6", "AP-5", "CA-5", "LS-6", "Annihilation"]
 }
 
-// struct FightSettingsView_Previews: PreviewProvider {
-//    @State static var config: any MAATaskConfiguration = FightConfiguration.default()
-//    static var previews: some View {
-//        FightSettingsView(config: $config)
-//    }
-// }
+ struct FightSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        FightSettingsView(id: UUID())
+            .environmentObject(MAAViewModel())
+    }
+ }

--- a/MeoAsstMac/Configuration Views/InfrastSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/InfrastSettingsView.swift
@@ -227,9 +227,9 @@ private extension String {
     }
 }
 
-// struct InfrastSettingsView_Previews: PreviewProvider {
-//    @State static var config: any MAATaskConfiguration = InfrastConfiguration.default()
-//    static var previews: some View {
-//        InfrastSettingsView(config: $config)
-//    }
-// }
+ struct InfrastSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        InfrastSettingsView(id: UUID())
+            .environmentObject(MAAViewModel())
+    }
+ }

--- a/MeoAsstMac/Configuration Views/MallSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/MallSettingsView.swift
@@ -36,12 +36,12 @@ struct MallSettingsView: View {
     }
 }
 
-// struct MallSettingsView_Previews: PreviewProvider {
-//    @State static var config: any MAATaskConfiguration = MallConfiguration.default()
-//    static var previews: some View {
-//        MallSettingsView(config: $config)
-//    }
-// }
+ struct MallSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        MallSettingsView(id: UUID())
+            .environmentObject(MAAViewModel())
+    }
+ }
 
 // MARK: - EditableTextList
 

--- a/MeoAsstMac/Configuration Views/ReclamationSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/ReclamationSettingsView.swift
@@ -34,9 +34,9 @@ struct ReclamationSettingsView: View {
     }
 }
 
-//struct ReclamationSettingsView_Previews: PreviewProvider {
-//    @State static var config: any MAATaskConfiguration = ReclamationConfiguration.default()
-//    static var previews: some View {
-//        ReclamationSettingsView(config: $config)
-//    }
-//}
+struct ReclamationSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        ReclamationSettingsView(id: UUID())
+            .environmentObject(MAAViewModel())
+    }
+}

--- a/MeoAsstMac/Configuration Views/RecruitSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/RecruitSettingsView.swift
@@ -27,7 +27,7 @@ struct RecruitSettingsView: View {
                 Text("每次执行时最大招募次数: \(config.times.wrappedValue)").padding(.vertical)
             }
 
-            Toggle("手动确认“支援机械”", isOn: config.skip_robot)
+            Toggle("手动确认1星", isOn: config.skip_robot)
             Toggle("自动确认3星", isOn: autoConfirm(level: 3))
             Toggle("自动确认4星", isOn: autoConfirm(level: 4))
             Toggle("自动确认5星", isOn: autoConfirm(level: 5))
@@ -63,9 +63,9 @@ struct RecruitSettingsView: View {
     }
 }
 
-// struct RecruitSettingsView_Previews: PreviewProvider {
-//    @State static var config: any MAATaskConfiguration = RecruitConfiguration.default()
-//    static var previews: some View {
-//        RecruitSettingsView(config: $config)
-//    }
-// }
+struct RecruitSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        RecruitSettingsView(id: UUID())
+            .environmentObject(MAAViewModel())
+    }
+}

--- a/MeoAsstMac/Configuration Views/RoguelikeSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/RoguelikeSettingsView.swift
@@ -71,12 +71,12 @@ struct RoguelikeSettingsView: View {
     }
 }
 
-// struct RoguelikeSettingsView_Previews: PreviewProvider {
-//    @State static var config: any MAATaskConfiguration = RoguelikeConfiguration.default()
-//    static var previews: some View {
-//        RoguelikeSettingsView(config: $config)
-//    }
-// }
+ struct RoguelikeSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        RoguelikeSettingsView(id: UUID())
+            .environmentObject(MAAViewModel())
+    }
+ }
 
 // MARK: - Constants
 

--- a/MeoAsstMac/Configuration Views/StartupSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/StartupSettingsView.swift
@@ -32,8 +32,9 @@ struct StartupSettingsView: View {
     }
 }
 
-// struct StartupSettingsView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        StartupSettingsView(id: MAAViewModel().tasks.randomElement()?.id ?? UUID())
-//    }
-// }
+ struct StartupSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        StartupSettingsView(id: UUID())
+            .environmentObject(MAAViewModel())
+    }
+ }

--- a/MeoAsstMac/Task Configurations/FightConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/FightConfiguration.swift
@@ -14,6 +14,7 @@ struct FightConfiguration: MAATaskConfiguration {
     var expiring_medicine: Int?
     var stone: Int?
     var times: Int?
+    var series: Int?
     var drops: [String: Int]?
 
     var report_to_penguin = false


### PR DESCRIPTION
1. ConfigurationView 启用预览
2. 添加连战次数选框 resolves MaaAssistantArknights/MaaAssistantArknights#9206
3. 启用企鹅物流（这个不知道什么原因没有启用？如果我做的不对的话就把这个删掉吧）