### PR TITLE
refactor: 简化 TaskConfiguration 的类型转换

### DIFF
--- a/MeoAsstMac/Configuration Views/AwardSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/AwardSettingsView.swift
@@ -8,26 +8,21 @@
 import SwiftUI
 
 struct AwardSettingsView: View {
-    @EnvironmentObject private var viewModel: MAAViewModel
-    let id: UUID
-
-    private var config: Binding<AwardConfiguration> {
-        viewModel.taskConfig(id: id)
-    }
+    @Binding var config: AwardConfiguration
 
     var body: some View {
         Form {
-            Toggle("领取每日/每周任务奖励", isOn: config.award)
+            Toggle("领取每日/每周任务奖励", isOn: $config.award)
 
-            Toggle("领取所有邮件奖励", isOn: config.mail)
+            Toggle("领取所有邮件奖励", isOn: $config.mail)
 
-            Toggle("进行每日免费单抽", isOn: config.recruit)
+            Toggle("进行每日免费单抽", isOn: $config.recruit)
 
-            Toggle("领取幸运墙合成玉奖励", isOn: config.orundum)
+            Toggle("领取幸运墙合成玉奖励", isOn: $config.orundum)
 
-            Toggle("领取限时开采许可合成玉奖励", isOn: config.mining)
+            Toggle("领取限时开采许可合成玉奖励", isOn: $config.mining)
 
-            Toggle("领取五周年赠送月卡奖励", isOn: config.specialaccess)
+            Toggle("领取五周年赠送月卡奖励", isOn: $config.specialaccess)
         }
         .padding()
     }
@@ -35,7 +30,6 @@ struct AwardSettingsView: View {
 
 struct AwardSettings_Preview: PreviewProvider {
     static var previews: some View {
-        AwardSettingsView(id: UUID())
-            .environmentObject(MAAViewModel())
+        AwardSettingsView(config: .constant(.init()))
     }
 }

--- a/MeoAsstMac/Configuration Views/MallSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/MallSettingsView.swift
@@ -8,27 +8,23 @@
 import SwiftUI
 
 struct MallSettingsView: View {
-    @EnvironmentObject private var viewModel: MAAViewModel
     @Environment(\.defaultMinListRowHeight) private var rowHeight
-    let id: UUID
 
-    private var config: Binding<MallConfiguration> {
-        viewModel.taskConfig(id: id)
-    }
+    @Binding var config: MallConfiguration
 
     var body: some View {
         VStack(spacing: 30) {
             HStack(spacing: 10) {
                 Spacer()
-                Toggle("信用购物", isOn: config.shopping)
-                Toggle("信用溢出时无视黑名单", isOn: config.force_shopping_if_credit_full)
+                Toggle("信用购物", isOn: $config.shopping)
+                Toggle("信用溢出时无视黑名单", isOn: $config.force_shopping_if_credit_full)
                 Toggle("借助战赚信用", isOn: .constant(false))
                 Spacer()
             }
 
             HStack(spacing: 20) {
-                EditableTextList(title: "优先购买", texts: config.buy_first)
-                EditableTextList(title: "黑名单", texts: config.blacklist)
+                EditableTextList(title: "优先购买", texts: $config.buy_first)
+                EditableTextList(title: "黑名单", texts: $config.blacklist)
             }
             .frame(height: 12 * rowHeight)
         }
@@ -38,8 +34,7 @@ struct MallSettingsView: View {
 
 struct MallSettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        MallSettingsView(id: UUID())
-            .environmentObject(MAAViewModel())
+        MallSettingsView(config: .constant(.init()))
     }
 }
 

--- a/MeoAsstMac/Configuration Views/ReclamationSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/ReclamationSettingsView.swift
@@ -8,45 +8,39 @@
 import SwiftUI
 
 struct ReclamationSettingsView: View {
-    @EnvironmentObject private var viewModel: MAAViewModel
-    let id: UUID
-
-    private var config: Binding<ReclamationConfiguration> {
-        viewModel.taskConfig(id: id)
-    }
+    @Binding var config: ReclamationConfiguration
 
     var body: some View {
         Form {
-            Picker("主题：", selection: config.theme) {
+            Picker("主题：", selection: $config.theme) {
                 ForEach(ReclamationTheme.allCases, id: \.rawValue) { theme in
                     Text("\(theme.description)").tag(theme)
                 }
             }
 
-            Picker("策略：", selection: config.mode) {
-                ForEach(config.wrappedValue.modes.sorted(by: <), id: \.key) { mode, desc in
+            Picker("策略：", selection: $config.mode) {
+                ForEach(config.modes.sorted(by: <), id: \.key) { mode, desc in
                     Text(desc).tag(mode)
                 }
             }
 
-            if config.wrappedValue.toolToCraftEnabled {
-                TextField("支援道具：", text: config.tool_to_craft)
-                TextField("组装批次数：", value: config.num_craft_batches, format: .number)
-                Picker("组装数量增加模式：", selection: config.increment_mode) {
-                    ForEach(config.wrappedValue.increment_modes.sorted(by: <), id: \.key) { increment_mode, desc in
+            if config.toolToCraftEnabled {
+                TextField("支援道具：", text: $config.tool_to_craft)
+                TextField("组装批次数：", value: $config.num_craft_batches, format: .number)
+                Picker("组装数量增加模式：", selection: $config.increment_mode) {
+                    ForEach(config.increment_modes.sorted(by: <), id: \.key) { increment_mode, desc in
                         Text(desc).tag(increment_mode)
                     }
                 }
             }
         }
-        .animation(.default, value: config.wrappedValue.toolToCraftEnabled)
+        .animation(.default, value: config.toolToCraftEnabled)
         .padding()
     }
 }
 
 struct ReclamationSettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        ReclamationSettingsView(id: UUID())
-            .environmentObject(MAAViewModel())
+        ReclamationSettingsView(config: .constant(.init()))
     }
 }

--- a/MeoAsstMac/Configuration Views/RecruitSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/RecruitSettingsView.swift
@@ -8,30 +8,25 @@
 import SwiftUI
 
 struct RecruitSettingsView: View {
-    @EnvironmentObject private var viewModel: MAAViewModel
-    let id: UUID
-
-    private var config: Binding<RecruitConfiguration> {
-        viewModel.taskConfig(id: id)
-    }
+    @Binding var config: RecruitConfiguration
 
     var body: some View {
         VStack(alignment: .leading) {
-            Toggle("自动刷新3星Tags", isOn: config.refresh)
+            Toggle("自动刷新3星Tags", isOn: $config.refresh)
 
-            Toggle("自动使用加急许可", isOn: config.expedite)
+            Toggle("自动使用加急许可", isOn: $config.expedite)
 
             Toggle("3星设置7:40而非9:00", isOn: level3UseShortTime)
 
-            Stepper(value: config.times, in: 0 ... 1000) {
+            Stepper(value: $config.times, in: 0...1000) {
                 HStack {
                     Text("每次执行时最大招募次数: ")
-                    TextField("", value: config.times, format: .number)
+                    TextField("", value: $config.times, format: .number)
                         .frame(maxWidth: 50)
                 }
             }
 
-            Toggle("手动确认1星", isOn: config.skip_robot)
+            Toggle("手动确认1星", isOn: $config.skip_robot)
             Toggle("自动确认3星", isOn: autoConfirm(level: 3))
             Toggle("自动确认4星", isOn: autoConfirm(level: 4))
             Toggle("自动确认5星", isOn: autoConfirm(level: 5))
@@ -42,26 +37,26 @@ struct RecruitSettingsView: View {
 
     private var level3UseShortTime: Binding<Bool> {
         Binding {
-            config.recruitment_time["3"].wrappedValue == 460
+            config.recruitment_time["3"] == 460
         } set: { newValue in
             if newValue {
-                config.recruitment_time["3"].wrappedValue = 460
+                config.recruitment_time["3"] = 460
             } else {
-                config.recruitment_time["3"].wrappedValue = 540
+                config.recruitment_time["3"] = 540
             }
         }
     }
 
     private func autoConfirm(level: Int) -> Binding<Bool> {
         Binding {
-            config.confirm.wrappedValue.contains(level)
+            config.confirm.contains(level)
         } set: { newValue in
             if newValue {
-                var levels = Set(config.confirm.wrappedValue)
+                var levels = Set(config.confirm)
                 levels.insert(level)
-                config.confirm.wrappedValue = levels.sorted()
+                config.confirm = levels.sorted()
             } else {
-                config.confirm.wrappedValue.removeAll { $0 == level }
+                config.confirm.removeAll { $0 == level }
             }
         }
     }
@@ -69,7 +64,6 @@ struct RecruitSettingsView: View {
 
 struct RecruitSettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        RecruitSettingsView(id: UUID())
-            .environmentObject(MAAViewModel())
+        RecruitSettingsView(config: .constant(.init()))
     }
 }

--- a/MeoAsstMac/Configuration Views/RoguelikeSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/RoguelikeSettingsView.swift
@@ -8,12 +8,7 @@
 import SwiftUI
 
 struct RoguelikeSettingsView: View {
-    @EnvironmentObject private var viewModel: MAAViewModel
-    let id: UUID
-
-    private var config: Binding<RoguelikeConfiguration> {
-        viewModel.taskConfig(id: id)
-    }
+    @Binding var config: RoguelikeConfiguration
 
     var body: some View {
         Form {
@@ -23,72 +18,71 @@ struct RoguelikeSettingsView: View {
             Divider()
             squadSettings()
         }
-        .animation(.default, value: config.use_support.wrappedValue)
-        .animation(.default, value: config.start_with_elite_two.wrappedValue)
+        .animation(.default, value: config.use_support)
+        .animation(.default, value: config.start_with_elite_two)
         .padding()
     }
 
     @ViewBuilder private func generalSettings() -> some View {
-        Picker("肉鸽主题：", selection: config.theme) {
+        Picker("肉鸽主题：", selection: $config.theme) {
             ForEach(RoguelikeTheme.allCases, id: \.rawValue) { theme in
                 Text("\(theme.description)").tag(theme)
             }
         }
 
-        Picker("肉鸽难度：", selection: config.difficulty) {
-            ForEach(config.theme.wrappedValue.difficulties) {
+        Picker("肉鸽难度：", selection: $config.difficulty) {
+            ForEach(config.theme.difficulties) {
                 Text($0.description).tag($0.id)
             }
         }
 
-        Picker("策略：", selection: config.mode) {
-            ForEach(config.theme.wrappedValue.modes) {
+        Picker("策略：", selection: $config.mode) {
+            ForEach(config.theme.modes) {
                 Text($0.description).tag($0.id)
             }
         }
 
-        TextField("最多探索次数：", value: config.starts_count, format: .number)
+        TextField("最多探索次数：", value: $config.starts_count, format: .number)
     }
 
     @ViewBuilder private func goldSettings() -> some View {
-        Toggle("投资源石锭", isOn: config.investment_enabled)
-        Toggle("刷新商店（指路鳞）", isOn: config.refresh_trader_with_dice)
-        Toggle("储备源石锭达到上限时停止", isOn: config.stop_when_investment_full)
+        Toggle("投资源石锭", isOn: $config.investment_enabled)
+        Toggle("刷新商店（指路鳞）", isOn: $config.refresh_trader_with_dice)
+        Toggle("储备源石锭达到上限时停止", isOn: $config.stop_when_investment_full)
 
-        TextField("最多投资源石锭数量：", value: config.investments_count, format: .number)
+        TextField("最多投资源石锭数量：", value: $config.investments_count, format: .number)
     }
 
     @ViewBuilder private func squadSettings() -> some View {
-        Picker("开局分队：", selection: config.squad) {
-            ForEach(config.theme.wrappedValue.squads, id: \.self) { squad in
+        Picker("开局分队：", selection: $config.squad) {
+            ForEach(config.theme.squads, id: \.self) { squad in
                 Text(squad).tag(squad)
             }
         }
 
-        Picker("开局职业组：", selection: config.roles) {
-            ForEach(config.wrappedValue.theme.roles, id: \.self) { role in
+        Picker("开局职业组：", selection: $config.roles) {
+            ForEach(config.theme.roles, id: \.self) { role in
                 Text(role).tag(role)
             }
         }
 
-        TextField("开局干员（单个）：", text: config.core_char)
+        TextField("开局干员（单个）：", text: $config.core_char)
 
-        Toggle("“开局干员”使用助战", isOn: config.use_support)
-        if config.use_support.wrappedValue {
-            Toggle("可以使用非好友助战", isOn: config.use_nonfriend_support)
+        Toggle("“开局干员”使用助战", isOn: $config.use_support)
+        if config.use_support {
+            Toggle("可以使用非好友助战", isOn: $config.use_nonfriend_support)
         }
 
-        Toggle("凹开局干员精二直升", isOn: config.start_with_elite_two)
-        if config.start_with_elite_two.wrappedValue {
-            Toggle("只凹直升不作战", isOn: config.only_start_with_elite_two)
+        Toggle("凹开局干员精二直升", isOn: $config.start_with_elite_two)
+        if config.start_with_elite_two {
+            Toggle("只凹直升不作战", isOn: $config.only_start_with_elite_two)
         }
     }
 }
 
 struct RoguelikeSettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        RoguelikeSettingsView(id: UUID())
-            .environmentObject(MAAViewModel())
+        RoguelikeSettingsView(config: .constant(.init()))
     }
 }
 

--- a/MeoAsstMac/Configuration Views/StartupSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/StartupSettingsView.swift
@@ -8,25 +8,20 @@
 import SwiftUI
 
 struct StartupSettingsView: View {
-    @EnvironmentObject private var viewModel: MAAViewModel
-    let id: UUID
-
-    private var config: Binding<StartupConfiguration> {
-        viewModel.taskConfig(id: id)
-    }
+    @Binding var config: StartupConfiguration
 
     var body: some View {
         Form {
             VStack(alignment: .leading, spacing: 3) {
-                Text("客户端类型：\(config.client_type.wrappedValue.description)")
+                Text("客户端类型：\(config.client_type.description)")
                 Text("请在“设置” > “游戏设置” 中选择客户端类型。")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
             .padding(.bottom)
 
-            Toggle("自动启动客户端", isOn: config.start_game_enabled)
-                .disabled(config.client_type.wrappedValue == .default)
+            Toggle("自动启动客户端", isOn: $config.start_game_enabled)
+                .disabled(config.client_type == .default)
         }
         .padding()
     }
@@ -34,7 +29,6 @@ struct StartupSettingsView: View {
 
 struct StartupSettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        StartupSettingsView(id: UUID())
-            .environmentObject(MAAViewModel())
+        StartupSettingsView(config: .constant(.init()))
     }
 }

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -529,32 +529,32 @@ extension MAAViewModel {
 // MARK: Task Configuration
 
 extension MAAViewModel {
-    func taskConfig<T: MAATaskConfiguration>(id: UUID) -> Binding<T> {
+    private func taskConfigBinding<T: MAATaskConfiguration>(id: UUID, config: T) -> Binding<T> {
         Binding {
-            self.tasks[id]?.unwrapConfig() ?? .init()
+            config
         } set: {
-            self.tasks[id] = .init(config: $0)
+            self.tasks[id] = $0.projectedTask
         }
     }
 
     @ViewBuilder func taskConfigView(id: UUID) -> some View {
         switch tasks[id] {
-        case .startup:
-            StartupSettingsView(id: id)
-        case .recruit:
-            RecruitSettingsView(id: id)
-        case .infrast:
-            InfrastSettingsView(id: id)
-        case .fight:
-            FightSettingsView(id: id)
-        case .mall:
-            MallSettingsView(id: id)
-        case .award:
-            AwardSettingsView(id: id)
-        case .roguelike:
-            RoguelikeSettingsView(id: id)
-        case .reclamation:
-            ReclamationSettingsView(id: id)
+        case .startup(let config):
+            StartupSettingsView(config: taskConfigBinding(id: id, config: config))
+        case .recruit(let config):
+            RecruitSettingsView(config: taskConfigBinding(id: id, config: config))
+        case .infrast(let config):
+            InfrastSettingsView(config: taskConfigBinding(id: id, config: config))
+        case .fight(let config):
+            FightSettingsView(config: taskConfigBinding(id: id, config: config))
+        case .mall(let config):
+            MallSettingsView(config: taskConfigBinding(id: id, config: config))
+        case .award(let config):
+            AwardSettingsView(config: taskConfigBinding(id: id, config: config))
+        case .roguelike(let config):
+            RoguelikeSettingsView(config: taskConfigBinding(id: id, config: config))
+        case .reclamation(let config):
+            ReclamationSettingsView(config: taskConfigBinding(id: id, config: config))
         case .closedown(_), .none:
             EmptyView()
         }

--- a/MeoAsstMac/Task Configurations/AwardConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/AwardConfiguration.swift
@@ -45,6 +45,10 @@ struct AwardConfiguration: MAATaskConfiguration {
     }
 
     var summary: String { "" }
+
+    var projectedTask: MAATask {
+        .award(self)
+    }
 }
 
 extension AwardConfiguration {

--- a/MeoAsstMac/Task Configurations/ClosedownConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/ClosedownConfiguration.swift
@@ -25,6 +25,10 @@ struct ClosedownConfiguration: MAATaskConfiguration {
     var summary: String {
         ""
     }
+
+    var projectedTask: MAATask {
+        .closedown(self)
+    }
 }
 
 extension ClosedownConfiguration {

--- a/MeoAsstMac/Task Configurations/FightConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/FightConfiguration.swift
@@ -53,6 +53,10 @@ struct FightConfiguration: MAATaskConfiguration {
         return parts.joined(separator: ";")
     }
 
+    var projectedTask: MAATask {
+        .fight(self)
+    }
+
     // 掉落物品列表
     static var dropItems: [(id: String, item: DropItem)] = []
     static var id2index: [String: Int] = [:] // (id -> idx of dropItems)

--- a/MeoAsstMac/Task Configurations/InfrastConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/InfrastConfiguration.swift
@@ -50,6 +50,10 @@ struct InfrastConfiguration: MAATaskConfiguration {
         }
     }
 
+    var projectedTask: MAATask {
+        .infrast(self)
+    }
+
     private var customPlan: MAAInfrast? {
         guard mode == 10000 else { return nil }
         return try? MAAInfrast(path: filename)

--- a/MeoAsstMac/Task Configurations/MAATaskConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/MAATaskConfiguration.swift
@@ -14,7 +14,7 @@ protocol MAATaskConfiguration: Codable & Hashable {
     var subtitle: String { get }
     var summary: String { get }
 
-    init()
+    var projectedTask: MAATask { get }
 }
 
 extension MAATaskConfiguration {
@@ -48,58 +48,6 @@ extension MAATask {
             return config.jsonStringIfEnabled()
         case .reclamation(let config):
             return config.jsonStringIfEnabled()
-        }
-    }
-}
-
-// MARK: Type-erased TaskConfig
-
-extension MAATask {
-    func unwrapConfig<T: MAATaskConfiguration>() -> T {
-        switch self {
-        case .startup(let config):
-            return config as? T ?? .init()
-        case .closedown(let config):
-            return config as? T ?? .init()
-        case .recruit(let config):
-            return config as? T ?? .init()
-        case .infrast(let config):
-            return config as? T ?? .init()
-        case .fight(let config):
-            return config as? T ?? .init()
-        case .mall(let config):
-            return config as? T ?? .init()
-        case .award(let config):
-            return config as? T ?? .init()
-        case .roguelike(let config):
-            return config as? T ?? .init()
-        case .reclamation(let config):
-            return config as? T ?? .init()
-        }
-    }
-
-    init<T: MAATaskConfiguration>(config: T) {
-        switch config {
-        case let newConfig as StartupConfiguration:
-            self = .startup(newConfig)
-        case let newConfig as ClosedownConfiguration:
-            self = .closedown(newConfig)
-        case let newConfig as RecruitConfiguration:
-            self = .recruit(newConfig)
-        case let newConfig as InfrastConfiguration:
-            self = .infrast(newConfig)
-        case let newConfig as FightConfiguration:
-            self = .fight(newConfig)
-        case let newConfig as MallConfiguration:
-            self = .mall(newConfig)
-        case let newConfig as AwardConfiguration:
-            self = .award(newConfig)
-        case let newConfig as RoguelikeConfiguration:
-            self = .roguelike(newConfig)
-        case let newConfig as ReclamationConfiguration:
-            self = .reclamation(newConfig)
-        default:
-            self = .closedown(.init())
         }
     }
 }

--- a/MeoAsstMac/Task Configurations/MallConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/MallConfiguration.swift
@@ -29,4 +29,8 @@ struct MallConfiguration: MAATaskConfiguration {
     var summary: String {
         buy_first.joined(separator: ";")
     }
+
+    var projectedTask: MAATask {
+        .mall(self)
+    }
 }

--- a/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
@@ -52,6 +52,10 @@ struct ReclamationConfiguration: MAATaskConfiguration {
     var summary: String {
         modes[mode] ?? ""
     }
+
+    var projectedTask: MAATask {
+        .reclamation(self)
+    }
 }
 
 enum ReclamationTheme: String, CaseIterable, Codable, CustomStringConvertible {

--- a/MeoAsstMac/Task Configurations/RecruitConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/RecruitConfiguration.swift
@@ -36,6 +36,10 @@ struct RecruitConfiguration: MAATaskConfiguration {
         return "★\(levelString)"
     }
 
+    var projectedTask: MAATask {
+        .recruit(self)
+    }
+
     static var recognition: RecruitConfiguration {
         .init(refresh: false, select: [4, 5, 6], confirm: [], times: 0)
     }

--- a/MeoAsstMac/Task Configurations/RoguelikeConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/RoguelikeConfiguration.swift
@@ -48,6 +48,10 @@ struct RoguelikeConfiguration: MAATaskConfiguration {
     var summary: String {
         "\(RoguelikeDifficulty(id: difficulty).description) \(RoguelikeMode(id: mode).shortDescription) \(core_char)"
     }
+
+    var projectedTask: MAATask {
+        .roguelike(self)
+    }
 }
 
 extension RoguelikeConfiguration {

--- a/MeoAsstMac/Task Configurations/StartupConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/StartupConfiguration.swift
@@ -27,6 +27,10 @@ struct StartupConfiguration: MAATaskConfiguration {
             return ""
         }
     }
+
+    var projectedTask: MAATask {
+        .startup(self)
+    }
 }
 
 enum MAAClientChannel: String, Codable, CaseIterable, CustomStringConvertible {


### PR DESCRIPTION
## 🚀 背景与动机

为了实现统一的序列化，并充分地利用类型约束，`MAATask` 的设计采用了枚举类型和协议：

```swift
enum MAATask {
    case startup(StartupConfiguration)
    case fight(FightConfiguration)
}

protocol MAATaskConfiguration: Codable {
    var enable: Bool { get set }
}

struct StartupConfiguration: MAATaskConfiguration {
    var enable = true
    var channel = "Official"
}

struct FightConfiguration: MAATaskConfiguration {
    var enable = true
    var stage = "1-7"
}
```

在原本的实现中，`MAATask.unwrapConfig` 和 `MAATask.init` 并不合理，带来了大量重复代码和不必要的类型转换。

```swift
func unwrapConfig<T: MAATaskConfiguration>() -> T {
    switch self {
    case .startup(let config):
        return config as? T ?? .init()
    case .fight(let config):
        return config as? T ?? .init()
    }
}

init<T: MAATaskConfiguration>(config: T) {
    switch config {
    case let newConfig as StartupConfiguration:
        self = .startup(newConfig)
    case let newConfig as FightConfiguration:
        self = .fight(newConfig)
    default:
        fatalError("unknown configuration")
    }
}
```

上述方法中已经枚举了配置的具体类型，输入输出却使用了泛型，显然是舍近求远的错误设计。

## ✍️ 修改方案

首先解决 `MAATask.init`，直接在具体类型中定义反射即可。可以发现，旧方法中尝试每一种类型其实是多此一举。

```swift
protocol MAATaskConfiguration {
    var projectedTask: MAATask { get }
}

extension StartupConfiguration {
    var projectedTask: MAATask {
        .startup(self)
    }
}

extension FightConfiguration {
    var projectedTask: MAATask {
        .fight(self)
    }
}

let config = StartupConfiguration()
let task1 = MAATask(config)          // old
let task2 = config.projectedTask     // new
```

对于 `MAATask.unwrapConfig`，关键在于在调用时尽可能保持枚举过程的上下文。在检查调用方后发现，本应该在 `MAAViewModel. taskConfigView` 的内部就获取到具体类型的配置。不应该继续传递 id，让视图去解析配置。因此将视图的输入直接改为配置即可，顺带还能精简到很多视图里的代码。

具体实现可参考 [MeoAsstMac/Model/MAAViewModel.swift](https://github.com/MaaAssistantArknights/MaaMacGui/pull/31/files#diff-11a4dcceca9d78d2e250ebae357529143f5a437bfafc7a05ce9828ffe9a8e159)。

## ✈️ 后续计划

重构后，更多的视图可以实现数据驱动，从而与全局状态解耦。随着配置项目越来越复杂，图形界面的选项无法和核心参数一一对应。因此接下来打算进一步拓展任务配置，将图形界面的配置项和传给核心的参数分离开，从而实现更加完善的界面设计和参数转换。

**CC:** @Alan-Charred ，请帮忙检查本次修改是否有功能上的问题，如果有任何疑问或建议欢迎在下方回复。