### PR TITLE
refactor: 单独实现任务参数的序列化

### DIFF
--- a/MeoAsstMac/Task Configurations/AwardConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/AwardConfiguration.swift
@@ -49,6 +49,12 @@ struct AwardConfiguration: MAATaskConfiguration {
     var projectedTask: MAATask {
         .award(self)
     }
+
+    typealias Params = Self
+
+    var params: Self {
+        self
+    }
 }
 
 extension AwardConfiguration {

--- a/MeoAsstMac/Task Configurations/ClosedownConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/ClosedownConfiguration.swift
@@ -29,6 +29,12 @@ struct ClosedownConfiguration: MAATaskConfiguration {
     var projectedTask: MAATask {
         .closedown(self)
     }
+
+    typealias Params = Self
+
+    var params: Self {
+        self
+    }
 }
 
 extension ClosedownConfiguration {

--- a/MeoAsstMac/Task Configurations/FightConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/FightConfiguration.swift
@@ -57,6 +57,12 @@ struct FightConfiguration: MAATaskConfiguration {
         .fight(self)
     }
 
+    typealias Params = Self
+
+    var params: Self {
+        self
+    }
+
     // 掉落物品列表
     static var dropItems: [(id: String, item: DropItem)] = []
     static var id2index: [String: Int] = [:] // (id -> idx of dropItems)

--- a/MeoAsstMac/Task Configurations/InfrastConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/InfrastConfiguration.swift
@@ -54,6 +54,12 @@ struct InfrastConfiguration: MAATaskConfiguration {
         .infrast(self)
     }
 
+    typealias Params = Self
+
+    var params: Self {
+        self
+    }
+
     private var customPlan: MAAInfrast? {
         guard mode == 10000 else { return nil }
         return try? MAAInfrast(path: filename)

--- a/MeoAsstMac/Task Configurations/MAATaskConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/MAATaskConfiguration.swift
@@ -15,13 +15,16 @@ protocol MAATaskConfiguration: Codable & Hashable {
     var summary: String { get }
 
     var projectedTask: MAATask { get }
+
+    associatedtype Params: Encodable
+    var params: Params { get }
 }
 
 extension MAATaskConfiguration {
     func jsonStringIfEnabled() -> String? {
         guard enable else { return nil }
 
-        return try? jsonString()
+        return try? params.jsonString()
     }
 }
 

--- a/MeoAsstMac/Task Configurations/MallConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/MallConfiguration.swift
@@ -33,4 +33,10 @@ struct MallConfiguration: MAATaskConfiguration {
     var projectedTask: MAATask {
         .mall(self)
     }
+
+    typealias Params = Self
+
+    var params: Self {
+        self
+    }
 }

--- a/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
@@ -56,6 +56,12 @@ struct ReclamationConfiguration: MAATaskConfiguration {
     var projectedTask: MAATask {
         .reclamation(self)
     }
+
+    typealias Params = Self
+
+    var params: Self {
+        self
+    }
 }
 
 enum ReclamationTheme: String, CaseIterable, Codable, CustomStringConvertible {

--- a/MeoAsstMac/Task Configurations/RecruitConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/RecruitConfiguration.swift
@@ -40,6 +40,12 @@ struct RecruitConfiguration: MAATaskConfiguration {
         .recruit(self)
     }
 
+    typealias Params = Self
+
+    var params: Self {
+        self
+    }
+
     static var recognition: RecruitConfiguration {
         .init(refresh: false, select: [4, 5, 6], confirm: [], times: 0)
     }

--- a/MeoAsstMac/Task Configurations/RoguelikeConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/RoguelikeConfiguration.swift
@@ -52,6 +52,12 @@ struct RoguelikeConfiguration: MAATaskConfiguration {
     var projectedTask: MAATask {
         .roguelike(self)
     }
+
+    typealias Params = Self
+
+    var params: Self {
+        self
+    }
 }
 
 extension RoguelikeConfiguration {

--- a/MeoAsstMac/Task Configurations/StartupConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/StartupConfiguration.swift
@@ -31,6 +31,12 @@ struct StartupConfiguration: MAATaskConfiguration {
     var projectedTask: MAATask {
         .startup(self)
     }
+
+    typealias Params = Self
+
+    var params: Self {
+        self
+    }
 }
 
 enum MAAClientChannel: String, Codable, CaseIterable, CustomStringConvertible {


### PR DESCRIPTION
After: #31.

- 为任务配置添加一个新的类型 `MAATaskConfiguration`，并使用 `params` 接口获取。
  - `Params` 专门为传递给核心的参数设计，`MAATaskConfiguration` 自身的数据作为图形界面的配置使用。
  - 作为最小化实现，目前 `Params` 均为配置自身，即 `typealias Params = Self`，后续会根据需要区分开。
- **TODO**: 实现配置的迁移，支持多配置。