### PR TITLE
feat: 旧版任务配置迁移

### DIFF
--- a/MeoAsstMac.xcodeproj/project.pbxproj
+++ b/MeoAsstMac.xcodeproj/project.pbxproj
@@ -57,7 +57,6 @@
 		8347B5AF2CDF925400AEB627 /* URLSession+downloadProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8347B5AE2CDF925400AEB627 /* URLSession+downloadProgress.swift */; };
 		834DEC122C4D94BD0073B5D4 /* ClosedownConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834DEC112C4D94BD0073B5D4 /* ClosedownConfiguration.swift */; };
 		83531D5F29F00F0A008A5DF8 /* CopilotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83531D5E29F00F0A008A5DF8 /* CopilotView.swift */; };
-		83531D6129F026E8008A5DF8 /* OrderedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83531D6029F026E8008A5DF8 /* OrderedStore.swift */; };
 		83531D6329F0A033008A5DF8 /* MAAInfrast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83531D6229F0A033008A5DF8 /* MAAInfrast.swift */; };
 		8355E7AE29E7F9DD005D5A1C /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8355E7AD29E7F9DD005D5A1C /* ContentView.swift */; };
 		8355E7B029E8722E005D5A1C /* TaskCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8355E7AF29E8722E005D5A1C /* TaskCell.swift */; };
@@ -66,6 +65,8 @@
 		83661E2C29F77CFF007793CA /* VideoRecogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83661E2B29F77CFF007793CA /* VideoRecogView.swift */; };
 		8366DE0129F2F26100F715E8 /* OperBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8366DE0029F2F26100F715E8 /* OperBoxView.swift */; };
 		8366DE0329F2F34100F715E8 /* MAAOperBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8366DE0229F2F34100F715E8 /* MAAOperBox.swift */; };
+		83782A2B2CFFAF2900A32BDD /* LegacyConfigurations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83782A2A2CFFAF2900A32BDD /* LegacyConfigurations.swift */; };
+		83782A2D2CFFB00000A32BDD /* LegacyUserTasks in Frameworks */ = {isa = PBXBuildFile; productRef = 83782A2C2CFFB00000A32BDD /* LegacyUserTasks */; };
 		8383EA2D28F2AF23007DAB9D /* MaaMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8383EA2C28F2AF23007DAB9D /* MaaMessage.swift */; };
 		8383EA2F28F2C5BD007DAB9D /* FightSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8383EA2E28F2C5BD007DAB9D /* FightSettingsView.swift */; };
 		838FF82229FBB9E3000566A0 /* GameSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 838FF82129FBB9E3000566A0 /* GameSettingsView.swift */; };
@@ -169,7 +170,6 @@
 		8347B5AE2CDF925400AEB627 /* URLSession+downloadProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+downloadProgress.swift"; sourceTree = "<group>"; };
 		834DEC112C4D94BD0073B5D4 /* ClosedownConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedownConfiguration.swift; sourceTree = "<group>"; };
 		83531D5E29F00F0A008A5DF8 /* CopilotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotView.swift; sourceTree = "<group>"; };
-		83531D6029F026E8008A5DF8 /* OrderedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedStore.swift; sourceTree = "<group>"; };
 		83531D6229F0A033008A5DF8 /* MAAInfrast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MAAInfrast.swift; sourceTree = "<group>"; };
 		8355E7AD29E7F9DD005D5A1C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; tabWidth = 2; };
 		8355E7AF29E8722E005D5A1C /* TaskCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskCell.swift; sourceTree = "<group>"; };
@@ -179,6 +179,8 @@
 		8366DE0029F2F26100F715E8 /* OperBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperBoxView.swift; sourceTree = "<group>"; };
 		8366DE0229F2F34100F715E8 /* MAAOperBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MAAOperBox.swift; sourceTree = "<group>"; };
 		8368855029BD851F00C5B999 /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
+		83782A282CFFA43200A32BDD /* LegacyUserTasks */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = LegacyUserTasks; sourceTree = "<group>"; };
+		83782A2A2CFFAF2900A32BDD /* LegacyConfigurations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyConfigurations.swift; sourceTree = "<group>"; };
 		8383EA2C28F2AF23007DAB9D /* MaaMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaaMessage.swift; sourceTree = "<group>"; };
 		8383EA2E28F2C5BD007DAB9D /* FightSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FightSettingsView.swift; sourceTree = "<group>"; };
 		83885C112C4D5D1500B02663 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8329859529EDB9EB009F7ED5 /* SwiftyJSON in Frameworks */,
+				83782A2D2CFFB00000A32BDD /* LegacyUserTasks in Frameworks */,
 				830C3D1C29BC7D8600B13A9F /* Sparkle in Frameworks */,
 				833F7B2A29A34C440001DB2D /* fastdeploy_ppocr.xcframework in Frameworks */,
 				831D2489293C9CE3005AC1CE /* MaaCore.xcframework in Frameworks */,
@@ -246,6 +249,7 @@
 				8341194F29EC249E00044F45 /* RoguelikeConfiguration.swift */,
 				8341195429EC55C600044F45 /* CopilotConfiguration.swift */,
 				832985AF29EEF483009F7ED5 /* ReclamationConfiguration.swift */,
+				83782A2A2CFFAF2900A32BDD /* LegacyConfigurations.swift */,
 			);
 			path = "Task Configurations";
 			sourceTree = "<group>";
@@ -328,6 +332,7 @@
 				83661E2529F628DA007793CA /* Resources */,
 				8368855029BD851F00C5B999 /* Version.xcconfig */,
 				83885C112C4D5D1500B02663 /* README.md */,
+				83782A292CFFA43200A32BDD /* Packages */,
 				833786CC28F188D800D39D6F /* Products */,
 				83245A0128F467C300ED6D4C /* Frameworks */,
 			);
@@ -402,7 +407,6 @@
 				832985B329EF1219009F7ED5 /* MAARecruit.swift */,
 				83CFD47029EAACD7000428A1 /* MAATask.swift */,
 				83264A3D29EC22DE0074E33A /* MAAViewModel.swift */,
-				83531D6029F026E8008A5DF8 /* OrderedStore.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -413,6 +417,14 @@
 				8320E6632CFE004D00F4BC95 /* Localizable.xcstrings */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		83782A292CFFA43200A32BDD /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				83782A282CFFA43200A32BDD /* LegacyUserTasks */,
+			);
+			path = Packages;
 			sourceTree = "<group>";
 		};
 		83FF5A98297855E5000AE831 /* Settings */ = {
@@ -460,6 +472,7 @@
 				830C3D1B29BC7D8600B13A9F /* Sparkle */,
 				8329859429EDB9EB009F7ED5 /* SwiftyJSON */,
 				8347B5AA2CDF89CC00AEB627 /* ZIPFoundation */,
+				83782A2C2CFFB00000A32BDD /* LegacyUserTasks */,
 			);
 			productName = MeoAsstMac;
 			productReference = 833786CB28F188D800D39D6F /* MAA.app */;
@@ -585,10 +598,10 @@
 				8347B5A82CDF85A000AEB627 /* ResourceUpdateView.swift in Sources */,
 				8391C9FA2B2746FA0047DB20 /* MaaToolClient.swift in Sources */,
 				838FF82729FDD0F9000566A0 /* GachaView.swift in Sources */,
+				83782A2B2CFFAF2900A32BDD /* LegacyConfigurations.swift in Sources */,
 				83264A2F29EBEE140074E33A /* RecruitConfiguration.swift in Sources */,
 				8341195029EC249E00044F45 /* RoguelikeConfiguration.swift in Sources */,
 				83264A2B29EBED780074E33A /* StartupConfiguration.swift in Sources */,
-				83531D6129F026E8008A5DF8 /* OrderedStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -845,6 +858,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8347B5A92CDF89CC00AEB627 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
 			productName = ZIPFoundation;
+		};
+		83782A2C2CFFB00000A32BDD /* LegacyUserTasks */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = LegacyUserTasks;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/MeoAsstMac/Core/Maa.swift
+++ b/MeoAsstMac/Core/Maa.swift
@@ -65,7 +65,7 @@ actor MAAHandle {
         uuidPointer.deallocate()
     }
 
-    func appendTask(type: MAATask.TypeName, params: String) throws -> Int32 {
+    func appendTask(type: MAATaskType, params: String) throws -> Int32 {
         let taskID = AsstAppendTask(handle, type.rawValue, params)
         if taskID == 0 {
             throw MaaCoreError.appendTaskFailed
@@ -119,6 +119,24 @@ actor MAAHandle {
     var running: Bool {
         AsstRunning(handle).isTrue
     }
+}
+
+enum MAATaskType: String {
+    case StartUp
+    case CloseDown
+    case Recruit
+    case Infrast
+    case Fight
+    case Mall
+    case Award
+    case Roguelike
+    case Copilot
+    case SSSCopilot
+    case Depot
+    case Reclamation
+    case VideoRecognition
+    case OperBox
+    case Custom
 }
 
 enum MaaCoreError: Error {

--- a/MeoAsstMac/Main Menu/TaskCommands.swift
+++ b/MeoAsstMac/Main Menu/TaskCommands.swift
@@ -12,7 +12,7 @@ struct TaskCommands: Commands {
 
     var body: some Commands {
         CommandMenu("任务") {
-            TaskButtons(viewModel: viewModel)
+            TaskButtons().environmentObject(viewModel)
         }
     }
 }

--- a/MeoAsstMac/Model/MAATask.swift
+++ b/MeoAsstMac/Model/MAATask.swift
@@ -17,91 +17,21 @@ enum MAATask: Codable, Equatable {
     case award(AwardConfiguration)
     case roguelike(RoguelikeConfiguration)
     case reclamation(ReclamationConfiguration)
-
-    enum TypeName: String {
-        case StartUp
-        case CloseDown
-        case Recruit
-        case Infrast
-        case Fight
-        case Mall
-        case Award
-        case Roguelike
-        case Copilot
-        case SSSCopilot
-        case Depot
-        case Reclamation
-        case VideoRecognition
-        case OperBox
-        case Custom
-    }
-
-    static let defaults: [MAATask] = [
-        .startup(.init()),
-        .recruit(.init()),
-        .infrast(.init()),
-        .fight(.init()),
-        .mall(.init()),
-        .award(.init()),
-        .roguelike(.init()),
-        .reclamation(.init()),
-        .closedown(.init()),
-    ]
-
-    init(type: TypeName) {
-        switch type {
-        case .StartUp:
-            self = .startup(.init())
-        case .CloseDown:
-            self = .closedown(.init())
-        case .Recruit:
-            self = .recruit(.init())
-        case .Infrast:
-            self = .infrast(.init())
-        case .Fight:
-            self = .fight(.init())
-        case .Mall:
-            self = .mall(.init())
-        case .Award:
-            self = .award(.init())
-        case .Roguelike:
-            self = .roguelike(.init())
-        case .Reclamation:
-            self = .reclamation(.init())
-        default:
-            self = .award(.init())
-        }
-    }
 }
 
-// MARK: Task Type
+let defaultTaskConfigurations: [any MAATaskConfiguration] = [
+    StartupConfiguration(),
+    RecruitConfiguration(),
+    InfrastConfiguration(),
+    FightConfiguration(),
+    MallConfiguration(),
+    AwardConfiguration(),
+    RoguelikeConfiguration(),
+    ReclamationConfiguration(),
+    ClosedownConfiguration(),
+]
 
-extension MAATask {
-    var typeName: TypeName {
-        switch self {
-        case .startup:
-            return .StartUp
-        case .closedown:
-            return .CloseDown
-        case .recruit:
-            return .Recruit
-        case .infrast:
-            return .Infrast
-        case .fight:
-            return .Fight
-        case .mall:
-            return .Mall
-        case .award:
-            return .Award
-        case .roguelike:
-            return .Roguelike
-        case .reclamation:
-            return .Reclamation
-        }
-    }
-}
-
-extension MAATask.TypeName: Codable, CustomStringConvertible {
+extension MAATaskType: Codable, CustomStringConvertible {
     var description: String {
         switch self {
         case .StartUp:
@@ -136,10 +66,6 @@ extension MAATask.TypeName: Codable, CustomStringConvertible {
             return NSLocalizedString("自定义", comment: "")
         }
     }
-
-    static var daily: [MAATask.TypeName] {
-        [.Recruit, .Infrast, .Fight, .Mall, .Award, .Roguelike, .Reclamation, .CloseDown]
-    }
 }
 
 // MARK: Task Persistance
@@ -151,12 +77,12 @@ struct DailyTask: Codable, Equatable, Identifiable {
 }
 
 extension DailyTask {
-    init(_ task: MAATask) {
-        switch task {
-        case .roguelike, .reclamation:
-            self.init(id: UUID(), task: task, enabled: false)
+    init<T: MAATaskConfiguration>(config: T) {
+        switch config.type {
+        case .Roguelike, .Reclamation:
+            self.init(id: UUID(), task: config.projectedTask, enabled: false)
         default:
-            self.init(id: UUID(), task: task, enabled: true)
+            self.init(id: UUID(), task: config.projectedTask, enabled: true)
         }
     }
 }
@@ -177,8 +103,8 @@ extension Array where Element == DailyTask {
         firstIndex { $0.id == id }
     }
 
-    mutating func append(_ task: MAATask) {
-        append(.init(task))
+    mutating func append<T: MAATaskConfiguration>(config: T) {
+        append(.init(config: config))
     }
 
     mutating func remove(id: UUID) {

--- a/MeoAsstMac/Model/MAATask.swift
+++ b/MeoAsstMac/Model/MAATask.swift
@@ -93,7 +93,7 @@ extension Array where Element == DailyTask {
             first { $0.id == id }?.task
         }
         set {
-            if let newValue, let index = firstIndex(where: { $0.id == id }) {
+            if let newValue, let index = firstIndex(id: id) {
                 self[index] = .init(id: id, task: newValue, enabled: self[index].enabled)
             }
         }

--- a/MeoAsstMac/Model/MAATask.swift
+++ b/MeoAsstMac/Model/MAATask.swift
@@ -230,7 +230,7 @@ extension MAATask {
 // MARK: Task Persistance
 
 extension MAAViewModel {
-    func writeBack(_ newValue: OrderedStore<MAATask>) {
+    func writeBack(_ newValue: [DailyTask]) {
         let data = try? PropertyListEncoder().encode(newValue)
         try? data?.write(to: tasksURL)
     }

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -167,7 +167,7 @@ import SwiftUI
                 tasks = try migrateLegacyConfigurations()
                 print("Migrated")
             } catch {
-                tasks = MAATask.defaults.map { .init($0) }
+                tasks = defaultTaskConfigurations.map { .init(config: $0) }
             }
         }
 
@@ -402,9 +402,9 @@ extension MAAViewModel {
         try await ensureHandle()
 
         for task in tasks {
-            guard let params = task.params else { continue }
+            guard task.enabled else { continue }
 
-            if let coreID = try await handle?.appendTask(type: task.task.typeName, params: params) {
+            if let coreID = try await handle?.appendTask(task.task) {
                 taskIDMap[coreID] = task.id
             }
         }

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -149,7 +149,6 @@ import SwiftUI
         do {
             let data = try Data(contentsOf: tasksURL)
             tasks = try PropertyListDecoder().decode([DailyTask].self, from: data)
-            print("Read from \(tasksURL.path)")
         } catch {
             var isDirectory: ObjCBool = false
             let exists = FileManager.default.fileExists(atPath: tasksDirectory.path, isDirectory: &isDirectory)
@@ -165,7 +164,6 @@ import SwiftUI
 
             do {
                 tasks = try migrateLegacyConfigurations()
-                print("Migrated")
             } catch {
                 tasks = defaultTaskConfigurations.map { .init(config: $0) }
             }

--- a/MeoAsstMac/Navigation/TaskDetail.swift
+++ b/MeoAsstMac/Navigation/TaskDetail.swift
@@ -15,8 +15,27 @@ struct TaskDetail: View {
         VStack {
             switch viewModel.dailyTasksDetailMode {
             case .taskConfig:
-                if let id {
-                    viewModel.taskConfigView(id: id)
+                if let id, let task = viewModel.tasks[id] {
+                    switch task {
+                    case .startup(let config):
+                        StartupSettingsView(config: taskConfigBinding(config, id: id))
+                    case .recruit(let config):
+                        RecruitSettingsView(config: taskConfigBinding(config, id: id))
+                    case .infrast(let config):
+                        InfrastSettingsView(config: taskConfigBinding(config, id: id))
+                    case .fight(let config):
+                        FightSettingsView(config: taskConfigBinding(config, id: id))
+                    case .mall(let config):
+                        MallSettingsView(config: taskConfigBinding(config, id: id))
+                    case .award(let config):
+                        AwardSettingsView(config: taskConfigBinding(config, id: id))
+                    case .roguelike(let config):
+                        RoguelikeSettingsView(config: taskConfigBinding(config, id: id))
+                    case .reclamation(let config):
+                        ReclamationSettingsView(config: taskConfigBinding(config, id: id))
+                    case .closedown(_):
+                        EmptyView()
+                    }
                 } else {
                     Text("Please select one task to config")
                 }
@@ -28,6 +47,14 @@ struct TaskDetail: View {
         }
         .padding()
         .toolbar(content: detailToolbar)
+    }
+
+    private func taskConfigBinding<T: MAATaskConfiguration>(_ value: T, id: UUID) -> Binding<T> {
+        Binding {
+            value
+        } set: {
+            viewModel.tasks[id] = $0.projectedTask
+        }
     }
 
     // MARK: - Toolbar
@@ -52,7 +79,8 @@ struct TaskDetail: View {
 
                 ViewDetaiTabButton(mode: .taskConfig, icon: "gearshape", selection: $viewModel.dailyTasksDetailMode)
                 ViewDetaiTabButton(mode: .log, icon: "note.text", selection: $viewModel.dailyTasksDetailMode)
-                ViewDetaiTabButton(mode: .timerConfig, icon: "clock.arrow.2.circlepath", selection: $viewModel.dailyTasksDetailMode)
+                ViewDetaiTabButton(
+                    mode: .timerConfig, icon: "clock.arrow.2.circlepath", selection: $viewModel.dailyTasksDetailMode)
             }
         }
     }

--- a/MeoAsstMac/Navigation/TaskDetail.swift
+++ b/MeoAsstMac/Navigation/TaskDetail.swift
@@ -62,9 +62,9 @@ struct TaskDetail: View {
     @ToolbarContentBuilder private func detailToolbar() -> some ToolbarContent {
         ToolbarItemGroup {
             Menu {
-                ForEach(MAATask.TypeName.daily, id: \.self) { name in
-                    Button(name.description) {
-                        addTask(MAATask(type: name))
+                ForEach(defaultTaskConfigurations.dropFirst(), id: \.type) { config in
+                    Button(config.title) {
+                        addTask(config: config)
                     }
                 }
             } label: {
@@ -87,8 +87,8 @@ struct TaskDetail: View {
 
     // MARK: - Actions
 
-    private func addTask(_ task: MAATask) {
-        viewModel.tasks.append(task)
+    private func addTask<T: MAATaskConfiguration>(config: T) {
+        viewModel.tasks.append(config: config)
         viewModel.newTaskAdded = true
     }
 }

--- a/MeoAsstMac/Navigation/TasksContent.swift
+++ b/MeoAsstMac/Navigation/TasksContent.swift
@@ -13,8 +13,27 @@ struct TasksContent: View {
 
     var body: some View {
         List(selection: $selection) {
-            ForEach(viewModel.tasks.keys, id: \.self) { id in
-                TaskCell(id: id)
+            ForEach($viewModel.tasks, id: \.id) { $task in
+                switch task.task {
+                case .startup(let config):
+                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                case .closedown(let config):
+                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                case .recruit(let config):
+                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                case .infrast(let config):
+                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                case .fight(let config):
+                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                case .mall(let config):
+                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                case .award(let config):
+                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                case .roguelike(let config):
+                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                case .reclamation(let config):
+                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                }
             }
             .onMove(perform: moveTask)
         }
@@ -73,16 +92,16 @@ struct TasksContent: View {
 
     private func deleteSelectedTask() {
         guard viewModel.tasks.count > 1,
-              let selection,
-              let index = viewModel.tasks.firstIndex(id: selection)
+            let selection,
+            let index = viewModel.tasks.firstIndex(id: selection)
         else {
             return
         }
         viewModel.tasks.remove(id: selection)
-        if index >= viewModel.tasks.keys.count {
-            self.selection = viewModel.tasks.keys.last
+        if index >= viewModel.tasks.count {
+            self.selection = viewModel.tasks.last?.id
         } else {
-            self.selection = viewModel.tasks.keys[index]
+            self.selection = viewModel.tasks[index].id
         }
     }
 
@@ -98,7 +117,7 @@ struct TasksContent: View {
 
     private func selectLastTask(_ shouldSelect: Bool) {
         if shouldSelect {
-            selection = viewModel.tasks.keys.last
+            selection = viewModel.tasks.last?.id
         }
     }
 

--- a/MeoAsstMac/Navigation/TasksContent.swift
+++ b/MeoAsstMac/Navigation/TasksContent.swift
@@ -87,7 +87,7 @@ struct TasksContent: View {
     }
 
     private func moveTask(from: IndexSet, to: Int) {
-        viewModel.tasks.keys.move(fromOffsets: from, toOffset: to)
+        viewModel.tasks.move(fromOffsets: from, toOffset: to)
     }
 
     private func deselectTask(_ viewMode: MAAViewModel.DailyTasksDetailMode) {

--- a/MeoAsstMac/Task Configurations/AwardConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/AwardConfiguration.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 struct AwardConfiguration: MAATaskConfiguration {
+    var type: MAATaskType { .Award }
+
     var award = true
     var mail = true
     var recruit = false
@@ -16,7 +18,7 @@ struct AwardConfiguration: MAATaskConfiguration {
     var specialaccess = false
 
     var title: String {
-        MAATask.TypeName.Award.description
+        type.description
     }
 
     var subtitle: String {

--- a/MeoAsstMac/Task Configurations/AwardConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/AwardConfiguration.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct AwardConfiguration: MAATaskConfiguration {
-    var enable = true
     var award = true
     var mail = true
     var recruit = false
@@ -60,7 +59,6 @@ struct AwardConfiguration: MAATaskConfiguration {
 extension AwardConfiguration {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.enable = try container.decode(Bool.self, forKey: .enable)
 
         // Migration
         self.award = try container.decodeIfPresent(Bool.self, forKey: .award) ?? false

--- a/MeoAsstMac/Task Configurations/ClosedownConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/ClosedownConfiguration.swift
@@ -8,10 +8,12 @@
 import Foundation
 
 struct ClosedownConfiguration: MAATaskConfiguration {
+    var type: MAATaskType { .CloseDown }
+
     var client_type = MAAClientChannel.default
 
     var title: String {
-        MAATask.TypeName.CloseDown.description
+        type.description
     }
 
     var subtitle: String {

--- a/MeoAsstMac/Task Configurations/ClosedownConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/ClosedownConfiguration.swift
@@ -8,10 +8,6 @@
 import Foundation
 
 struct ClosedownConfiguration: MAATaskConfiguration {
-    var enable = true
-
-    // Requires migration, see `init(from:)`.
-
     var client_type = MAAClientChannel.default
 
     var title: String {
@@ -40,10 +36,6 @@ struct ClosedownConfiguration: MAATaskConfiguration {
 extension ClosedownConfiguration {
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.enable = try container.decode(Bool.self, forKey: .enable)
-
-        // Migration
-
         self.client_type = (try? container.decode(MAAClientChannel.self, forKey: .client_type)) ?? .default
     }
 }

--- a/MeoAsstMac/Task Configurations/FightConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/FightConfiguration.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct FightConfiguration: MAATaskConfiguration {
-    var enable = true
     var stage = ""
     var medicine: Int?
     var expiring_medicine: Int?

--- a/MeoAsstMac/Task Configurations/FightConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/FightConfiguration.swift
@@ -66,40 +66,42 @@ struct FightConfiguration: MAATaskConfiguration {
 
     // 掉落物品列表
     static var dropItems: [(id: String, item: DropItem)] = []
-    static var id2index: [String: Int] = [:] // (id -> idx of dropItems)
+    static var id2index: [String: Int] = [:]  // (id -> idx of dropItems)
     static let _excludedValues = Set([
-        3213, 3223, 3233, 3243, // 双芯片
-        3253, 3263, 3273, 3283, // 双芯片
-        7001, 7002, 7003, 7004, // 许可
-        6001, // 演习卷
-        4004, 4005, // 凭证
-        3141, 4002, // 源石
-        32001, // 芯片助剂
-        30115, // 聚合剂
-        30125, // 双极纳米片
-        30135, // D32钢
-        30145, // 晶体电子单元
-        30155, // 烧结核凝晶
+        3213, 3223, 3233, 3243,  // 双芯片
+        3253, 3263, 3273, 3283,  // 双芯片
+        7001, 7002, 7003, 7004,  // 许可
+        6001,  // 演习卷
+        4004, 4005,  // 凭证
+        3141, 4002,  // 源石
+        32001,  // 芯片助剂
+        30115,  // 聚合剂
+        30125,  // 双极纳米片
+        30135,  // D32钢
+        30145,  // 晶体电子单元
+        30155,  // 烧结核凝晶
     ])
 
     static func initDropItems(_ language: String) throws {
         if !dropItems.isEmpty { return }
-        let local: String? = switch language {
-        case "zh-tw": "txwy"
-        case "en-us": "YoStarEN"
-        case "ja-jp": "YoStarJP"
-        case "ko-kr": "YoStarKR"
-        default: nil
-        }
+        let local: String? =
+            switch language {
+            case "zh-tw": "txwy"
+            case "en-us": "YoStarEN"
+            case "ja-jp": "YoStarJP"
+            case "ko-kr": "YoStarKR"
+            default: nil
+            }
         let url_base = Bundle.main.resourceURL!
             .appendingPathComponent("resource")
-        let url_mid = if let local {
-            url_base.appendingPathComponent("global")
-                .appendingPathComponent(local)
-                .appendingPathComponent("resource")
-        } else {
-            url_base
-        }
+        let url_mid =
+            if let local {
+                url_base.appendingPathComponent("global")
+                    .appendingPathComponent(local)
+                    .appendingPathComponent("resource")
+            } else {
+                url_base
+            }
         let url = url_mid.appendingPathComponent("item_index.json")
         let data = try Data(contentsOf: url)
         let json = try JSONDecoder().decode([String: DropItem].self, from: data)

--- a/MeoAsstMac/Task Configurations/FightConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/FightConfiguration.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 struct FightConfiguration: MAATaskConfiguration {
+    var type: MAATaskType { .Fight }
+
     var stage = ""
     var medicine: Int?
     var expiring_medicine: Int?
@@ -23,7 +25,7 @@ struct FightConfiguration: MAATaskConfiguration {
     var DrGrandet = false
 
     var title: String {
-        MAATask.TypeName.Fight.description
+        type.description
     }
 
     var subtitle: String {

--- a/MeoAsstMac/Task Configurations/InfrastConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/InfrastConfiguration.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct InfrastConfiguration: MAATaskConfiguration {
-    var enable = true
     var mode = 0
 
     var facility = MAAInfrastFacility.allCases

--- a/MeoAsstMac/Task Configurations/InfrastConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/InfrastConfiguration.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 struct InfrastConfiguration: MAATaskConfiguration {
+    var type: MAATaskType { .Infrast }
+
     var mode = 0
 
     var facility = MAAInfrastFacility.allCases
@@ -22,7 +24,7 @@ struct InfrastConfiguration: MAATaskConfiguration {
     var plan_index = 0
 
     var title: String {
-        MAATask.TypeName.Infrast.description
+        type.description
     }
 
     var subtitle: String {

--- a/MeoAsstMac/Task Configurations/LegacyConfigurations.swift
+++ b/MeoAsstMac/Task Configurations/LegacyConfigurations.swift
@@ -1,0 +1,148 @@
+//
+//  LegacyConfigurations.swift
+//  MAA
+//
+//  Created by hguandl on 2024/12/4.
+//
+
+import LegacyUserTasks
+
+func migrateLegacyConfigurations() throws -> [MAATask] {
+    try legacyTasks().map { task in
+        switch task {
+        case .startup(let config):
+            MAATask.startup(.init(migrating: config))
+        case .closedown(let config):
+            MAATask.closedown(.init(migrating: config))
+        case .recruit(let config):
+            MAATask.recruit(.init(migrating: config))
+        case .infrast(let config):
+            MAATask.infrast(.init(migrating: config))
+        case .fight(let config):
+            MAATask.fight(.init(migrating: config))
+        case .mall(let config):
+            MAATask.mall(.init(migrating: config))
+        case .award(let config):
+            MAATask.award(.init(migrating: config))
+        case .roguelike(let config):
+            MAATask.roguelike(.init(migrating: config))
+        case .reclamation(let config):
+            MAATask.reclamation(.init(migrating: config))
+        }
+    }
+}
+
+extension StartupConfiguration {
+    fileprivate init(migrating config: LegacyStartupConfiguration) {
+        self.enable = config.enable
+        self.start_game_enabled = config.start_game_enabled
+        self.client_type = .init(rawValue: config.client_type.rawValue) ?? .default
+    }
+}
+
+extension ClosedownConfiguration {
+    fileprivate init(migrating config: LegacyClosedownConfiguration) {
+        self.enable = config.enable
+        self.client_type = .init(rawValue: config.client_type.rawValue) ?? .default
+    }
+}
+
+extension RecruitConfiguration {
+    fileprivate init(migrating config: LegacyRecruitConfiguration) {
+        self.enable = config.enable
+        self.refresh = config.refresh
+        self.select = config.select
+        self.confirm = config.confirm
+        self.times = config.times
+        self.set_time = config.set_time
+        self.expedite = config.expedite
+        self.skip_robot = config.skip_robot
+        self.recruitment_time = config.recruitment_time
+    }
+}
+
+extension InfrastConfiguration {
+    fileprivate init(migrating config: LegacyInfrastConfiguration) {
+        self.enable = config.enable
+        self.mode = config.mode
+        self.facility = config.facility.compactMap { .init(rawValue: $0.rawValue) }
+        self.drones = .init(rawValue: config.drones.rawValue) ?? .NotUse
+        self.threshold = config.threshold
+        self.replenish = config.replenish
+        self.dorm_notstationed_enabled = config.dorm_notstationed_enabled
+        self.dorm_trust_enabled = config.dorm_trust_enabled
+        self.filename = config.filename
+        self.plan_index = config.plan_index
+    }
+}
+
+extension FightConfiguration {
+    fileprivate init(migrating config: LegacyFightConfiguration) {
+        self.enable = config.enable
+        self.stage = config.stage
+        self.medicine = config.medicine
+        self.expiring_medicine = config.expiring_medicine
+        self.stone = config.stone
+        self.times = config.times
+        self.series = config.series
+        self.drops = config.drops
+        self.report_to_penguin = config.report_to_penguin
+        self.penguin_id = config.penguin_id
+        self.server = config.server
+        self.client_type = config.client_type
+        self.DrGrandet = config.DrGrandet
+    }
+}
+
+extension MallConfiguration {
+    fileprivate init(migrating config: LegacyMallConfiguration) {
+        self.enable = config.enable
+        self.shopping = config.shopping
+        self.buy_first = config.buy_first
+        self.blacklist = config.blacklist
+        self.force_shopping_if_credit_full = config.force_shopping_if_credit_full
+    }
+}
+
+extension AwardConfiguration {
+    fileprivate init(migrating config: LegacyAwardConfiguration) {
+        self.enable = config.enable
+        self.award = config.award
+        self.mail = config.mail
+        self.recruit = config.recruit
+        self.orundum = config.orundum
+        self.mining = config.mining
+        self.specialaccess = config.specialaccess
+    }
+}
+
+extension RoguelikeConfiguration {
+    fileprivate init(migrating config: LegacyRoguelikeConfiguration) {
+        self.enable = config.enable
+        self.theme = .init(rawValue: config.theme.rawValue) ?? .Phantom
+        self.difficulty = config.difficulty
+        self.mode = config.mode
+        self.starts_count = config.starts_count
+        self.investment_enabled = config.investment_enabled
+        self.investments_count = config.investments_count
+        self.stop_when_investment_full = config.stop_when_investment_full
+        self.squad = config.squad
+        self.roles = config.roles
+        self.core_char = config.core_char
+        self.start_with_elite_two = config.start_with_elite_two
+        self.use_support = config.use_support
+        self.use_nonfriend_support = config.use_nonfriend_support
+        self.refresh_trader_with_dice = config.refresh_trader_with_dice
+    }
+}
+
+extension ReclamationConfiguration {
+    fileprivate init(migrating config: LegacyReclamationConfiguration) {
+        self.enable = config.enable
+        self.theme = .init(rawValue: config.theme.rawValue) ?? .tales
+        self.mode = config.mode
+        self.tool_to_craft = config.tool_to_craft
+        self.num_craft_batches = config.num_craft_batches
+        self.increment_mode = config.increment_mode
+    }
+}

--- a/MeoAsstMac/Task Configurations/LegacyConfigurations.swift
+++ b/MeoAsstMac/Task Configurations/LegacyConfigurations.swift
@@ -5,36 +5,45 @@
 //  Created by hguandl on 2024/12/4.
 //
 
+import Foundation
 import LegacyUserTasks
 
-func migrateLegacyConfigurations() throws -> [MAATask] {
+func migrateLegacyConfigurations() throws -> [DailyTask] {
     try legacyTasks().map { task in
         switch task {
         case .startup(let config):
-            MAATask.startup(.init(migrating: config))
+            let task = MAATask.startup(.init(migrating: config))
+            return .init(id: UUID(), task: task, enabled: config.enable)
         case .closedown(let config):
-            MAATask.closedown(.init(migrating: config))
+            let task = MAATask.closedown(.init(migrating: config))
+            return .init(id: UUID(), task: task, enabled: config.enable)
         case .recruit(let config):
-            MAATask.recruit(.init(migrating: config))
+            let task = MAATask.recruit(.init(migrating: config))
+            return .init(id: UUID(), task: task, enabled: config.enable)
         case .infrast(let config):
-            MAATask.infrast(.init(migrating: config))
+            let task = MAATask.infrast(.init(migrating: config))
+            return .init(id: UUID(), task: task, enabled: config.enable)
         case .fight(let config):
-            MAATask.fight(.init(migrating: config))
+            let task = MAATask.fight(.init(migrating: config))
+            return .init(id: UUID(), task: task, enabled: config.enable)
         case .mall(let config):
-            MAATask.mall(.init(migrating: config))
+            let task = MAATask.mall(.init(migrating: config))
+            return .init(id: UUID(), task: task, enabled: config.enable)
         case .award(let config):
-            MAATask.award(.init(migrating: config))
+            let task = MAATask.award(.init(migrating: config))
+            return .init(id: UUID(), task: task, enabled: config.enable)
         case .roguelike(let config):
-            MAATask.roguelike(.init(migrating: config))
+            let task = MAATask.roguelike(.init(migrating: config))
+            return .init(id: UUID(), task: task, enabled: config.enable)
         case .reclamation(let config):
-            MAATask.reclamation(.init(migrating: config))
+            let task = MAATask.reclamation(.init(migrating: config))
+            return .init(id: UUID(), task: task, enabled: config.enable)
         }
     }
 }
 
 extension StartupConfiguration {
     fileprivate init(migrating config: LegacyStartupConfiguration) {
-        self.enable = config.enable
         self.start_game_enabled = config.start_game_enabled
         self.client_type = .init(rawValue: config.client_type.rawValue) ?? .default
     }
@@ -42,14 +51,12 @@ extension StartupConfiguration {
 
 extension ClosedownConfiguration {
     fileprivate init(migrating config: LegacyClosedownConfiguration) {
-        self.enable = config.enable
         self.client_type = .init(rawValue: config.client_type.rawValue) ?? .default
     }
 }
 
 extension RecruitConfiguration {
     fileprivate init(migrating config: LegacyRecruitConfiguration) {
-        self.enable = config.enable
         self.refresh = config.refresh
         self.select = config.select
         self.confirm = config.confirm
@@ -63,7 +70,6 @@ extension RecruitConfiguration {
 
 extension InfrastConfiguration {
     fileprivate init(migrating config: LegacyInfrastConfiguration) {
-        self.enable = config.enable
         self.mode = config.mode
         self.facility = config.facility.compactMap { .init(rawValue: $0.rawValue) }
         self.drones = .init(rawValue: config.drones.rawValue) ?? .NotUse
@@ -78,7 +84,6 @@ extension InfrastConfiguration {
 
 extension FightConfiguration {
     fileprivate init(migrating config: LegacyFightConfiguration) {
-        self.enable = config.enable
         self.stage = config.stage
         self.medicine = config.medicine
         self.expiring_medicine = config.expiring_medicine
@@ -96,7 +101,6 @@ extension FightConfiguration {
 
 extension MallConfiguration {
     fileprivate init(migrating config: LegacyMallConfiguration) {
-        self.enable = config.enable
         self.shopping = config.shopping
         self.buy_first = config.buy_first
         self.blacklist = config.blacklist
@@ -106,7 +110,6 @@ extension MallConfiguration {
 
 extension AwardConfiguration {
     fileprivate init(migrating config: LegacyAwardConfiguration) {
-        self.enable = config.enable
         self.award = config.award
         self.mail = config.mail
         self.recruit = config.recruit
@@ -118,7 +121,6 @@ extension AwardConfiguration {
 
 extension RoguelikeConfiguration {
     fileprivate init(migrating config: LegacyRoguelikeConfiguration) {
-        self.enable = config.enable
         self.theme = .init(rawValue: config.theme.rawValue) ?? .Phantom
         self.difficulty = config.difficulty
         self.mode = config.mode
@@ -138,7 +140,6 @@ extension RoguelikeConfiguration {
 
 extension ReclamationConfiguration {
     fileprivate init(migrating config: LegacyReclamationConfiguration) {
-        self.enable = config.enable
         self.theme = .init(rawValue: config.theme.rawValue) ?? .tales
         self.mode = config.mode
         self.tool_to_craft = config.tool_to_craft

--- a/MeoAsstMac/Task Configurations/MAATaskConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/MAATaskConfiguration.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 protocol MAATaskConfiguration: Codable & Hashable {
-    var enable: Bool { get set }
-
     var title: String { get }
     var subtitle: String { get }
     var summary: String { get }
@@ -20,37 +18,30 @@ protocol MAATaskConfiguration: Codable & Hashable {
     var params: Params { get }
 }
 
-extension MAATaskConfiguration {
-    func jsonStringIfEnabled() -> String? {
-        guard enable else { return nil }
-
-        return try? params.jsonString()
-    }
-}
-
 // MARK: JSON TaskParams
 
-extension MAATask {
+extension DailyTask {
     var params: String? {
-        switch self {
+        guard enabled else { return nil }
+        switch task {
         case .startup(let config):
-            return config.jsonStringIfEnabled()
+            return try? config.params.jsonString()
         case .closedown(let config):
-            return config.jsonStringIfEnabled()
+            return try? config.params.jsonString()
         case .recruit(let config):
-            return config.jsonStringIfEnabled()
+            return try? config.params.jsonString()
         case .infrast(let config):
-            return config.jsonStringIfEnabled()
+            return try? config.params.jsonString()
         case .fight(let config):
-            return config.jsonStringIfEnabled()
+            return try? config.params.jsonString()
         case .mall(let config):
-            return config.jsonStringIfEnabled()
+            return try? config.params.jsonString()
         case .award(let config):
-            return config.jsonStringIfEnabled()
+            return try? config.params.jsonString()
         case .roguelike(let config):
-            return config.jsonStringIfEnabled()
+            return try? config.params.jsonString()
         case .reclamation(let config):
-            return config.jsonStringIfEnabled()
+            return try? config.params.jsonString()
         }
     }
 }

--- a/MeoAsstMac/Task Configurations/MAATaskConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/MAATaskConfiguration.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 protocol MAATaskConfiguration: Codable & Hashable {
+    var type: MAATaskType { get }
+
     var title: String { get }
     var subtitle: String { get }
     var summary: String { get }
@@ -20,28 +22,31 @@ protocol MAATaskConfiguration: Codable & Hashable {
 
 // MARK: JSON TaskParams
 
-extension DailyTask {
-    var params: String? {
-        guard enabled else { return nil }
+extension MAAHandle {
+    func appendTask(_ task: MAATask) throws -> Int32 {
         switch task {
         case .startup(let config):
-            return try? config.params.jsonString()
+            return try appendTask(config: config)
         case .closedown(let config):
-            return try? config.params.jsonString()
+            return try appendTask(config: config)
         case .recruit(let config):
-            return try? config.params.jsonString()
+            return try appendTask(config: config)
         case .infrast(let config):
-            return try? config.params.jsonString()
+            return try appendTask(config: config)
         case .fight(let config):
-            return try? config.params.jsonString()
+            return try appendTask(config: config)
         case .mall(let config):
-            return try? config.params.jsonString()
+            return try appendTask(config: config)
         case .award(let config):
-            return try? config.params.jsonString()
+            return try appendTask(config: config)
         case .roguelike(let config):
-            return try? config.params.jsonString()
+            return try appendTask(config: config)
         case .reclamation(let config):
-            return try? config.params.jsonString()
+            return try appendTask(config: config)
         }
+    }
+
+    fileprivate func appendTask<T: MAATaskConfiguration>(config: T) throws -> Int32 {
+        try appendTask(type: config.type, params: config.params.jsonString())
     }
 }

--- a/MeoAsstMac/Task Configurations/MallConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/MallConfiguration.swift
@@ -8,13 +8,15 @@
 import Foundation
 
 struct MallConfiguration: MAATaskConfiguration {
+    var type: MAATaskType { .Mall }
+
     var shopping = true
     var buy_first = ["招聘许可", "龙门币"]
     var blacklist = ["加急许可", "家具零件"]
     var force_shopping_if_credit_full = true
 
     var title: String {
-        MAATask.TypeName.Mall.description
+        type.description
     }
 
     var subtitle: String {

--- a/MeoAsstMac/Task Configurations/MallConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/MallConfiguration.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct MallConfiguration: MAATaskConfiguration {
-    var enable = true
     var shopping = true
     var buy_first = ["招聘许可", "龙门币"]
     var blacklist = ["加急许可", "家具零件"]

--- a/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct ReclamationConfiguration: MAATaskConfiguration {
-    var enable = false
     var theme = ReclamationTheme.tales
     var mode = 0
     var tool_to_craft = "荧光棒"

--- a/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
@@ -21,12 +21,12 @@ struct ReclamationConfiguration: MAATaskConfiguration {
         case .fire:
             return [
                 0: NSLocalizedString("刷分与建造点", comment: ""),
-                1: NSLocalizedString("刷赤金", comment: "")
+                1: NSLocalizedString("刷赤金", comment: ""),
             ]
         case .tales:
             return [
                 0: NSLocalizedString("无存档，通过进出关卡刷生息点数", comment: ""),
-                1: NSLocalizedString("有存档，通过组装支援道具刷生息点数，组装完成后将会跳到下一个量定日并读取前一个量定日的存档", comment: "")
+                1: NSLocalizedString("有存档，通过组装支援道具刷生息点数，组装完成后将会跳到下一个量定日并读取前一个量定日的存档", comment: ""),
             ]
         }
     }
@@ -34,7 +34,7 @@ struct ReclamationConfiguration: MAATaskConfiguration {
     var increment_modes: [Int: String] {
         return [
             0: NSLocalizedString("点击加号按钮", comment: ""),
-            1: NSLocalizedString("按住加号按钮", comment: "")
+            1: NSLocalizedString("按住加号按钮", comment: ""),
         ]
     }
 

--- a/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 struct ReclamationConfiguration: MAATaskConfiguration {
+    var type: MAATaskType { .Reclamation }
+
     var theme = ReclamationTheme.tales
     var mode = 0
     var tool_to_craft = "荧光棒"
@@ -41,7 +43,7 @@ struct ReclamationConfiguration: MAATaskConfiguration {
     }
 
     var title: String {
-        MAATask.TypeName.Reclamation.description
+        type.description
     }
 
     var subtitle: String {

--- a/MeoAsstMac/Task Configurations/RecruitConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/RecruitConfiguration.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 struct RecruitConfiguration: MAATaskConfiguration {
-    var enable = true
-
     var refresh = true
     var select = [4, 5]
     var confirm = [3, 4, 5]

--- a/MeoAsstMac/Task Configurations/RecruitConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/RecruitConfiguration.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 struct RecruitConfiguration: MAATaskConfiguration {
+    var type: MAATaskType { .Recruit }
+
     var refresh = true
     var select = [4, 5]
     var confirm = [3, 4, 5]
@@ -18,7 +20,7 @@ struct RecruitConfiguration: MAATaskConfiguration {
     var recruitment_time = ["3": 540, "4": 540, "5": 540, "6": 540]
 
     var title: String {
-        MAATask.TypeName.Recruit.description
+        type.description
     }
 
     var subtitle: String {

--- a/MeoAsstMac/Task Configurations/RoguelikeConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/RoguelikeConfiguration.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 struct RoguelikeConfiguration: MAATaskConfiguration {
+    var type: MAATaskType { .Roguelike }
+
     var theme = RoguelikeTheme.Phantom {
         didSet {
             if !theme.difficulties.contains(where: { $0.id == difficulty }) {
@@ -37,7 +39,7 @@ struct RoguelikeConfiguration: MAATaskConfiguration {
     var refresh_trader_with_dice = false
 
     var title: String {
-        MAATask.TypeName.Roguelike.description
+        type.description
     }
 
     var subtitle: String {

--- a/MeoAsstMac/Task Configurations/RoguelikeConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/RoguelikeConfiguration.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct RoguelikeConfiguration: MAATaskConfiguration {
-    var enable = false
     var theme = RoguelikeTheme.Phantom {
         didSet {
             if !theme.difficulties.contains(where: { $0.id == difficulty }) {
@@ -63,7 +62,6 @@ struct RoguelikeConfiguration: MAATaskConfiguration {
 extension RoguelikeConfiguration {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.enable = try container.decode(Bool.self, forKey: .enable)
         self.theme = try container.decode(RoguelikeTheme.self, forKey: .theme)
         self.mode = try container.decode(Int.self, forKey: .mode)
         self.starts_count = try container.decode(Int.self, forKey: .starts_count)
@@ -107,7 +105,6 @@ extension RoguelikeConfiguration {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(enable, forKey: .enable)
         try container.encode(theme, forKey: .theme)
         try container.encode(mode, forKey: .mode)
         try container.encode(squad, forKey: .squad)

--- a/MeoAsstMac/Task Configurations/StartupConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/StartupConfiguration.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct StartupConfiguration: MAATaskConfiguration {
-    var enable = true
     var client_type = MAAClientChannel.default
     var start_game_enabled = false
 

--- a/MeoAsstMac/Task Configurations/StartupConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/StartupConfiguration.swift
@@ -8,11 +8,13 @@
 import Foundation
 
 struct StartupConfiguration: MAATaskConfiguration {
+    var type: MAATaskType { .StartUp }
+
     var client_type = MAAClientChannel.default
     var start_game_enabled = false
 
     var title: String {
-        MAATask.TypeName.StartUp.description
+        type.description
     }
 
     var subtitle: String {

--- a/MeoAsstMac/Views/TaskButtons.swift
+++ b/MeoAsstMac/Views/TaskButtons.swift
@@ -28,8 +28,8 @@ struct TaskButtons: View {
 
         Button("全部启用") {
             for (index, task) in viewModel.tasks.enumerated() {
-                switch task.task.typeName {
-                case .Roguelike, .Reclamation:
+                switch task.task {
+                case .roguelike, .reclamation:
                     continue
                 default:
                     viewModel.tasks[index].enabled = true

--- a/MeoAsstMac/Views/TaskButtons.swift
+++ b/MeoAsstMac/Views/TaskButtons.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TaskButtons: View {
-    @ObservedObject var viewModel: MAAViewModel
+    @EnvironmentObject var viewModel: MAAViewModel
 
     var body: some View {
         Button("开始任务") {
@@ -27,20 +27,20 @@ struct TaskButtons: View {
         .keyboardShortcut(".", modifiers: .command)
 
         Button("全部启用") {
-            for id in viewModel.tasks.keys {
-                switch viewModel.tasks[id]?.typeName {
+            for (index, task) in viewModel.tasks.enumerated() {
+                switch task.task.typeName {
                 case .Roguelike, .Reclamation:
                     continue
                 default:
-                    viewModel.tasks[id]?.enabled = true
+                    viewModel.tasks[index].enabled = true
                 }
             }
         }
         .keyboardShortcut("E", modifiers: [.command, .shift])
 
         Button("全部取消") {
-            for id in viewModel.tasks.keys {
-                viewModel.tasks[id]?.enabled = false
+            for (index, _) in viewModel.tasks.enumerated() {
+                viewModel.tasks[index].enabled = false
             }
         }
         .keyboardShortcut("D", modifiers: [.command, .shift])
@@ -49,6 +49,6 @@ struct TaskButtons: View {
 
 struct TaskButtons_Previews: PreviewProvider {
     static var previews: some View {
-        TaskButtons(viewModel: MAAViewModel())
+        TaskButtons().environmentObject(MAAViewModel())
     }
 }

--- a/MeoAsstMac/Views/TaskCell.swift
+++ b/MeoAsstMac/Views/TaskCell.swift
@@ -7,36 +7,44 @@
 
 import SwiftUI
 
-struct TaskCell: View {
-    @EnvironmentObject private var viewModel: MAAViewModel
+struct TaskCell<Config: MAATaskConfiguration>: View {
     let id: UUID
+    let config: Config
+
+    @Binding var enabled: Bool
 
     var body: some View {
         HStack {
-            Toggle("", isOn: enabled)
+            Toggle("", isOn: $enabled)
             VStack(alignment: .leading, spacing: 4) {
-                Text(overview.title)
+                Text(config.title)
                     .font(.headline)
 
                 HStack {
-                    Text(overview.subtitle)
+                    Text(config.subtitle)
                         .font(.subheadline)
 
-                    Text(overview.summary)
+                    Text(config.summary)
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                 }
                 .lineLimit(1)
             }
             Spacer()
-            indicator
+            TaskIndicator(id: id)
         }
         .padding(.vertical, 6)
-        .animation(.default, value: viewModel.taskStatus[id])
-        .contextMenu(menuItems: menuItems)
+        .contextMenu {
+            TaskButtons()
+        }
     }
+}
 
-    @ViewBuilder private var indicator: some View {
+private struct TaskIndicator: View {
+    @EnvironmentObject private var viewModel: MAAViewModel
+    let id: UUID
+
+    var body: some View {
         switch viewModel.taskStatus[id] {
         case .cancel:
             Image(systemName: "slash.circle").foregroundColor(.secondary)
@@ -50,28 +58,11 @@ struct TaskCell: View {
             EmptyView()
         }
     }
-
-    @ViewBuilder private func menuItems() -> some View {
-        TaskButtons(viewModel: viewModel)
-    }
-
-    private var enabled: Binding<Bool> {
-        Binding {
-            viewModel.tasks[id]?.enabled ?? false
-        } set: { newValue in
-            viewModel.tasks[id]?.enabled = newValue
-        }
-    }
-
-    private var overview: MAATask.Overview {
-        viewModel.tasks[id]?.overview ?? ("", "", "")
-    }
 }
 
 struct MAATaskCell_Previews: PreviewProvider {
-    static var viewModel = MAAViewModel()
     static var previews: some View {
-        TaskCell(id: UUID())
-            .environmentObject(viewModel)
+        TaskCell(id: UUID(), config: StartupConfiguration(), enabled: .constant(true))
+            .environmentObject(MAAViewModel())
     }
 }

--- a/Packages/LegacyUserTasks/.gitignore
+++ b/Packages/LegacyUserTasks/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Packages/LegacyUserTasks/Package.swift
+++ b/Packages/LegacyUserTasks/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "LegacyUserTasks",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "LegacyUserTasks",
+            targets: ["LegacyUserTasks"])
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "LegacyUserTasks")
+
+    ]
+)

--- a/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Award.swift
+++ b/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Award.swift
@@ -1,0 +1,31 @@
+//
+//  Award.swift
+//  LegacyUserTasks
+//
+//  Created by hguandl on 16/4/2023.
+//
+
+import Foundation
+
+@frozen public struct LegacyAwardConfiguration: Codable {
+    public let enable: Bool
+    public let award: Bool
+    public let mail: Bool
+    public let recruit: Bool
+    public let orundum: Bool
+    public let mining: Bool
+    public let specialaccess: Bool
+}
+
+extension LegacyAwardConfiguration {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.enable = try container.decode(Bool.self, forKey: .enable)
+        self.award = try container.decodeIfPresent(Bool.self, forKey: .award) ?? false
+        self.mail = try container.decodeIfPresent(Bool.self, forKey: .mail) ?? false
+        self.recruit = try container.decodeIfPresent(Bool.self, forKey: .recruit) ?? false
+        self.orundum = try container.decodeIfPresent(Bool.self, forKey: .orundum) ?? false
+        self.mining = try container.decodeIfPresent(Bool.self, forKey: .mining) ?? false
+        self.specialaccess = try container.decodeIfPresent(Bool.self, forKey: .specialaccess) ?? false
+    }
+}

--- a/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Closedown.swift
+++ b/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Closedown.swift
@@ -1,0 +1,21 @@
+//
+//  Closedown.swift
+//  LegacyUserTasks
+//
+//  Created by hguandl on 2024/7/22.
+//
+
+import Foundation
+
+@frozen public struct LegacyClosedownConfiguration: Codable {
+    public let enable: Bool
+    public let client_type: LegacyMAAClientChannel
+}
+
+extension LegacyClosedownConfiguration {
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.enable = try container.decode(Bool.self, forKey: .enable)
+        self.client_type = (try? container.decode(LegacyMAAClientChannel.self, forKey: .client_type)) ?? .default
+    }
+}

--- a/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Fight.swift
+++ b/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Fight.swift
@@ -1,0 +1,24 @@
+//
+//  Fight.swift
+//  LegacyUserTasks
+//
+//  Created by hguandl on 16/4/2023.
+//
+
+import Foundation
+
+@frozen public struct LegacyFightConfiguration: Codable {
+    public let enable: Bool
+    public let stage: String
+    public let medicine: Int?
+    public let expiring_medicine: Int?
+    public let stone: Int?
+    public let times: Int?
+    public let series: Int?
+    public let drops: [String: Int]?
+    public let report_to_penguin: Bool
+    public let penguin_id: String
+    public let server: String
+    public let client_type: String
+    public let DrGrandet: Bool
+}

--- a/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Infrast.swift
+++ b/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Infrast.swift
@@ -1,0 +1,41 @@
+//
+//  Infrast.swift
+//  LegacyUserTasks
+//
+//  Created by hguandl on 16/4/2023.
+//
+
+import Foundation
+
+@frozen public struct LegacyInfrastConfiguration: Codable {
+    public let enable: Bool
+    public let mode: Int
+    public let facility: [MAALegacyInfrastFacility]
+    public let drones: MAALegacyInfrastDroneUsage
+    public let threshold: Double
+    public let replenish: Bool
+    public let dorm_notstationed_enabled: Bool
+    public let dorm_trust_enabled: Bool
+    public let filename: String
+    public let plan_index: Int
+}
+
+@frozen public enum MAALegacyInfrastFacility: String, Codable {
+    case Mfg
+    case Trade
+    case Power
+    case Control
+    case Reception
+    case Office
+    case Dorm
+}
+
+@frozen public enum MAALegacyInfrastDroneUsage: String, Codable {
+    case NotUse = "_NotUse"
+    case Money
+    case SyntheticJade
+    case CombatRecord
+    case PureGold
+    case OriginStone
+    case Chip
+}

--- a/Packages/LegacyUserTasks/Sources/LegacyUserTasks/LegacyUserTasks.swift
+++ b/Packages/LegacyUserTasks/Sources/LegacyUserTasks/LegacyUserTasks.swift
@@ -1,0 +1,38 @@
+//
+//  LegacyUserTasks.swift
+//  LegacyUserTasks
+//
+//  Created by hguandl on 2024/12/4.
+//
+
+import Foundation
+
+@frozen public enum MAALegacyTask: Codable {
+    case startup(LegacyStartupConfiguration)
+    case closedown(LegacyClosedownConfiguration)
+    case recruit(LegacyRecruitConfiguration)
+    case infrast(LegacyInfrastConfiguration)
+    case fight(LegacyFightConfiguration)
+    case mall(LegacyMallConfiguration)
+    case award(LegacyAwardConfiguration)
+    case roguelike(LegacyRoguelikeConfiguration)
+    case reclamation(LegacyReclamationConfiguration)
+}
+
+public func legacyTasks() throws -> [MAALegacyTask] {
+    let legacyTasksURL = FileManager.default
+        .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+        .first!
+        .appendingPathComponent("UserTasks")
+        .appendingPathExtension("plist")
+
+    if !FileManager.default.fileExists(atPath: legacyTasksURL.path) {
+        return []
+    }
+
+    let data = try Data(contentsOf: legacyTasksURL)
+    let tasks = try PropertyListDecoder().decode(OrderedStore<MAALegacyTask>.self, from: data)
+
+    try? FileManager.default.removeItem(at: legacyTasksURL)
+    return tasks.values
+}

--- a/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Mall.swift
+++ b/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Mall.swift
@@ -1,0 +1,16 @@
+//
+//  Mall.swift
+//  LegacyUserTasks
+//
+//  Created by hguandl on 16/4/2023.
+//
+
+import Foundation
+
+@frozen public struct LegacyMallConfiguration: Codable {
+    public let enable: Bool
+    public let shopping: Bool
+    public let buy_first: [String]
+    public let blacklist: [String]
+    public let force_shopping_if_credit_full: Bool
+}

--- a/Packages/LegacyUserTasks/Sources/LegacyUserTasks/OrderedStore.swift
+++ b/Packages/LegacyUserTasks/Sources/LegacyUserTasks/OrderedStore.swift
@@ -1,6 +1,6 @@
 //
 //  OrderedStore.swift
-//  MAA
+//  LegacyUserTasks
 //
 //  Created by hguandl on 19/4/2023.
 //

--- a/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Reclamation.swift
+++ b/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Reclamation.swift
@@ -9,14 +9,14 @@ import Foundation
 
 @frozen public struct LegacyReclamationConfiguration: Codable {
     public let enable: Bool
-    public let theme: ReclamationTheme
+    public let theme: LegacyReclamationTheme
     public let mode: Int
     public let tool_to_craft: String
     public let num_craft_batches: Int
     public let increment_mode: Int
 }
 
-@frozen public enum ReclamationTheme: String, Codable {
+@frozen public enum LegacyReclamationTheme: String, Codable {
     case fire = "Fire"
     case tales = "Tales"
 }

--- a/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Reclamation.swift
+++ b/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Reclamation.swift
@@ -1,0 +1,22 @@
+//
+//  Reclamation.swift
+//  LegacyUserTasks
+//
+//  Created by hguandl on 19/4/2023.
+//
+
+import Foundation
+
+@frozen public struct LegacyReclamationConfiguration: Codable {
+    public let enable: Bool
+    public let theme: ReclamationTheme
+    public let mode: Int
+    public let tool_to_craft: String
+    public let num_craft_batches: Int
+    public let increment_mode: Int
+}
+
+@frozen public enum ReclamationTheme: String, Codable {
+    case fire = "Fire"
+    case tales = "Tales"
+}

--- a/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Recruit.swift
+++ b/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Recruit.swift
@@ -1,0 +1,20 @@
+//
+//  Recruit.swift
+//  LegacyUserTasks
+//
+//  Created by hguandl on 16/4/2023.
+//
+
+import Foundation
+
+@frozen public struct LegacyRecruitConfiguration: Codable {
+    public let enable: Bool
+    public let refresh: Bool
+    public let select: [Int]
+    public let confirm: [Int]
+    public let times: Int
+    public let set_time: Bool
+    public let expedite: Bool
+    public let skip_robot: Bool
+    public let recruitment_time: [String: Int]
+}

--- a/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Roguelike.swift
+++ b/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Roguelike.swift
@@ -1,0 +1,56 @@
+//
+//  Roguelike.swift
+//  LegacyUserTasks
+//
+//  Created by hguandl on 16/4/2023.
+//
+
+import Foundation
+
+@frozen public struct LegacyRoguelikeConfiguration: Codable {
+    public let enable: Bool
+    public let theme: LegacyRoguelikeTheme
+    public let difficulty: Int
+    public let mode: Int
+    public let starts_count: Int
+    public let investment_enabled: Bool
+    public let investments_count: Int
+    public let stop_when_investment_full: Bool
+    public let squad: String
+    public let roles: String
+    public let core_char: String
+    public let start_with_elite_two: Bool
+    public let only_start_with_elite_two: Bool
+    public let use_support: Bool
+    public let use_nonfriend_support: Bool
+    public let refresh_trader_with_dice: Bool
+}
+
+extension LegacyRoguelikeConfiguration {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.enable = try container.decode(Bool.self, forKey: .enable)
+        self.theme = try container.decode(LegacyRoguelikeTheme.self, forKey: .theme)
+        self.mode = try container.decode(Int.self, forKey: .mode)
+        self.starts_count = try container.decode(Int.self, forKey: .starts_count)
+        self.investment_enabled = try container.decode(Bool.self, forKey: .investment_enabled)
+        self.investments_count = try container.decode(Int.self, forKey: .investments_count)
+        self.stop_when_investment_full = try container.decode(Bool.self, forKey: .stop_when_investment_full)
+        self.squad = try container.decode(String.self, forKey: .squad)
+        self.roles = try container.decode(String.self, forKey: .roles)
+        self.core_char = try container.decode(String.self, forKey: .core_char)
+        self.use_support = (try? container.decode(Bool.self, forKey: .use_support)) ?? false
+        self.use_nonfriend_support = (try? container.decode(Bool.self, forKey: .use_nonfriend_support)) ?? false
+        self.refresh_trader_with_dice = (try? container.decode(Bool.self, forKey: .refresh_trader_with_dice)) ?? false
+        self.start_with_elite_two = (try? container.decode(Bool.self, forKey: .start_with_elite_two)) ?? false
+        self.only_start_with_elite_two = (try? container.decode(Bool.self, forKey: .only_start_with_elite_two)) ?? false
+        self.difficulty = (try? container.decode(Int.self, forKey: .difficulty)) ?? -1
+    }
+}
+
+@frozen public enum LegacyRoguelikeTheme: String, CaseIterable, Codable {
+    case Phantom
+    case Mizuki
+    case Sami
+    case Sarkaz
+}

--- a/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Startup.swift
+++ b/Packages/LegacyUserTasks/Sources/LegacyUserTasks/Startup.swift
@@ -1,0 +1,24 @@
+//
+//  Startup.swift
+//  LegacyUserTasks
+//
+//  Created by hguandl on 16/4/2023.
+//
+
+import Foundation
+
+@frozen public struct LegacyStartupConfiguration: Codable {
+    public let enable: Bool
+    public let client_type: LegacyMAAClientChannel
+    public let start_game_enabled: Bool
+}
+
+@frozen public enum LegacyMAAClientChannel: String, Codable, CaseIterable {
+    case `default` = ""
+    case Official
+    case Bilibili
+    case YoStarEN
+    case YoStarJP
+    case YoStarKR
+    case txwy
+}


### PR DESCRIPTION
After: #31, #32.

- 创建独立模块 LegacyUserTasks
  - 拷贝现有的 Task Configurations
  - 移除不必要的内容，只保留序列化字段
  - 设置 `@frozen` 属性，字段改为只读
  - 更改名称，添加 `Legacy` 前缀
- 添加 LegacyConfigurations.swift
  - 获取旧配置文件里的内容
  - 实现字段迁移
- 更改 ViewModel
  - 适配新版配置
  - 初始化时迁移配置