### PR TITLE
feat(editable-text-list): 增强MallSettingsView可编辑列表的交互体验

### DIFF
--- a/MeoAsstMac/Configuration Views/MallSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/MallSettingsView.swift
@@ -67,13 +67,13 @@ private struct EditableTextList: View {
                     HStack {
                         TextField("", text: entry.element)
                             .focused($focusedField, equals: entry.id)
-                            //.textFieldStyle(.roundedBorder)
 
                         Button {
                             selection = entry.id
                             focusedField = entry.id
                         } label: {
                             Image(systemName: "pencil")
+                                .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
                     }


### PR DESCRIPTION
**Changes Introduced**
    - 为 EditableTextList 中的每一项添加了可视化编辑提示：
    - 点击“铅笔”图标后，对应行的 TextField 会自动聚焦，进入编辑状态
    - 使用 FocusState 实现精准控制 TextField 焦点状态

**Motivation**

用户在使用时难以发现某些列表项是可编辑的，尤其是在未主动点击 TextField 的情况下。通过添加图标和焦点控制，大幅提升可发现性和编辑体验。

**Screenshots / Previews**

![maa](https://github.com/user-attachments/assets/dc5344ee-b4e5-40c1-b069-5e5d8ebe41f9)
