### PR TITLE
feat: add AUTO for series option

### DIFF
--- a/MeoAsstMac/Configuration Views/FightSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/FightSettingsView.swift
@@ -51,18 +51,12 @@ struct FightSettingsView: View {
                     Toggle("指定次数", isOn: limitBattles)
                 }
 
-                Picker(selection: Binding(
-                    get: { config.series ?? -1 },
-                    set: { config.series = $0 == -1 ? nil : $0 }
-                )) {
-                    Text("AUTO").tag(0)
-                    Text("6").tag(6)
-                    Text("5").tag(5)
-                    Text("4").tag(4)
-                    Text("3").tag(3)
-                    Text("2").tag(2)
-                    Text("1").tag(1)
-                    Text("不使用").tag(-1)
+                Picker(selection: $config.series) {
+                    Text(verbatim: "AUTO").tag(0)
+                    ForEach((1...6).reversed(), id: \.self) { i in
+                        Text(verbatim: "\(i)").tag(i)
+                    }
+                    Text("不使用").tag(Int?.none)
                 } label: {
                     Toggle("连战次数", isOn: seriesBattles)
                 }
@@ -146,9 +140,9 @@ struct FightSettingsView: View {
 
     private var seriesBattles: Binding<Bool> {
         Binding {
-            config.series != nil && config.series != -1
+            config.series != nil
         } set: {
-            config.series = $0 ? 0 : -1  // Default to 0 (AUTO) if enabled, otherwise set to -1 (not in use)
+            config.series = $0 ? 0 : nil
         }
     }
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -70,12 +70,6 @@
     "1-7" : {
       "shouldTranslate" : false
     },
-    "2" : {
-
-    },
-    "3" : {
-
-    },
     "3星" : {
       "localizations" : {
         "ko" : {
@@ -89,9 +83,6 @@
     "3星设置7:40而非9:00" : {
 
     },
-    "4" : {
-
-    },
     "4星" : {
       "localizations" : {
         "ko" : {
@@ -102,9 +93,6 @@
         }
       }
     },
-    "5" : {
-
-    },
     "5星" : {
       "localizations" : {
         "ko" : {
@@ -114,9 +102,6 @@
           }
         }
       }
-    },
-    "6" : {
-
     },
     "6星" : {
       "localizations" : {
@@ -179,9 +164,6 @@
           }
         }
       }
-    },
-    "AUTO" : {
-
     },
     "BattleFormation: %@" : {
       "localizations" : {


### PR DESCRIPTION
modified seriesBattles binding to handle the new AUTO (0) and disabled (-1) states
added a picker for battle series configuration with options: AUTO, 1-6, and "不使用" (disabled)

给 mac 版加入自动连战次数的功能，将输入框更改为选择框，如果选择不使用则 config.series 传 -1

<img width="375" alt="image" src="https://github.com/user-attachments/assets/b70e1fdb-a9b1-4415-ba61-e2028a0d08e6" />
