### PR TITLE
fix: Crashes when previewing Navigation/MAAContent in Xcode

### DIFF
--- a/MeoAsstMac/Navigation/MAAContent.swift
+++ b/MeoAsstMac/Navigation/MAAContent.swift
@@ -32,6 +32,7 @@ struct MAAContent_Previews: PreviewProvider {
     static var previews: some View {
         MAAContent(sidebar: .constant(.daily),
                    selection: .constant(.init()))
+        .environmentObject(MAAViewModel())
     }
 }
 


### PR DESCRIPTION
修复了一下Navigation目录下MAAContent在Xcode中预览失败的问题。
修改方式如下：
```swift
struct MAAContent_Previews: PreviewProvider {
    static var previews: some View {
        MAAContent(sidebar: .constant(.daily),
                   selection: .constant(.init()))
        .environmentObject(MAAViewModel())            // -----> 新增
    }
}
```