### PR TITLE
feat: Add Connection Retry Limit to MaaToolClient Initialization

### DIFF
--- a/MeoAsstMac/Core/MaaToolClient.swift
+++ b/MeoAsstMac/Core/MaaToolClient.swift
@@ -14,8 +14,8 @@ actor MaaToolClient {
     init?(address: String) async {
         let parts = address.split(separator: ":")
         guard parts.count >= 2,
-              let portNumber = UInt16(parts[1]),
-              let port = NWEndpoint.Port(rawValue: portNumber)
+            let portNumber = UInt16(parts[1]),
+            let port = NWEndpoint.Port(rawValue: portNumber)
         else {
             return nil
         }
@@ -40,11 +40,19 @@ actor MaaToolClient {
 
         connection.start(queue: .global())
 
+        var retryCount = 0
+        let maxRetries = 20
+
         for await state in states {
             switch state {
             case .setup, .preparing, .cancelled:
                 break
             case .waiting, .failed:
+                retryCount += 1
+                if retryCount > maxRetries {
+                    connection.cancel()  // 取消连接
+                    return nil  // 达到最大重试次数，初始化失败
+                }
                 try? await Task.sleep(nanoseconds: 500_000_000)
                 connection.restart()
             case .ready:
@@ -62,13 +70,15 @@ actor MaaToolClient {
         let data = Data([0x4d, 0x41, 0x41, 0x00, 0x00, 0x04, 0x54, 0x45, 0x52, 0x4d])
 
         return try await withCheckedThrowingContinuation { continuation in
-            connection.send(content: data, completion: .contentProcessed { error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume()
-                }
-            })
+            connection.send(
+                content: data,
+                completion: .contentProcessed { error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume()
+                    }
+                })
         }
     }
 }


### PR DESCRIPTION
## **Summary**

This Pull Request introduces a **connection retry limit** during the initialization of **`MaaToolClient`**. This critical change prevents the client from entering an **infinite connection loop** when the target application unexpectedly quits, ensuring a more stable and responsive user interface that doesn't get stuck in a loading state.

The core mechanism involves tracking the number of connection retries and gracefully aborting the connection attempt after a defined threshold is reached.

### **Reason for Change**

When the Arknights game unexpectedly quits during startup (e.g., simulated by the provided force-kill script), the GUI's Start/Stop button becomes permanently locked in a loading state. This occurs because the `MaaToolClient` continuously tries to reconnect to the now-closed target application indefinitely.

The provided Python script demonstrates a way to simulate this failure by aggressively force-killing the application process (`com.hypergryph.arknights`):

```
import time
import os

KEYWORD_TO_CLOSE = "com.hypergryph.arknights" 
CHECK_INTERVAL = 0.2

def kill_with_pkill_force(keyword):
    # -i ignore case, -f match full command line, -9 send SIGKILL for force termination
    command = f'pkill -i -f "{keyword}"'
    
    # os.system(command) executes the command
    exit_code = os.system(command) 
    
    if exit_code == 0:
        print(f"Application '{keyword}' was forcefully closed (pkill -9).")
    else:
        print(f"No application '{keyword}' detected running.")


def main_pkill_partial():
    print(f"Program started. Monitoring keyword: **{KEYWORD_TO_CLOSE}** (using pkill -i -f)")
    print(f"Check interval: {CHECK_INTERVAL} seconds.")
    print("Press Ctrl+C to stop.")
    
    try:
        while True:
            kill_with_pkill_force(KEYWORD_TO_CLOSE)
            time.sleep(CHECK_INTERVAL)
            
    except KeyboardInterrupt:
        print("\nProgram stopped.")

main_pkill_partial()
```

Implementing a retry limit resolves this issue by allowing the client to fail fast and restore control to the GUI.

-----

### **Key Changes**

1.  **Retry Mechanism Implementation:**
      * The `init?(address: String)` method in `MaaToolClient` now includes a **`retryCount`** variable and a **`maxRetries`** constant (set to **20**).
      * The **`retryCount`** increments every time a connection retry is initiated.
2.  **Connection Abort Logic:**
      * If **`retryCount`** exceeds the **`maxRetries`** limit, the current **`NWConnection` is cancelled** (`connection.cancel()`).
      * The **`MaaToolClient` initialization subsequently fails** (returns `nil`), effectively terminating the infinite retry loop and unsticking the GUI.

-----

### **Files Affected**

  * `MaaToolClient.swift`

-----

-----

## **摘要**

本次拉取请求（PR）在 **`MaaToolClient`** 的初始化过程中引入了 **连接重试次数限制**。这项关键改动能够防止客户端在目标应用程序意外退出时陷入 **无限重连循环**，从而提供更稳健、响应更快的应用体验，避免用户界面卡在加载状态。

核心逻辑是通过跟踪重试连接次数，并在达到预设阈值后中止连接尝试。

### **更改原因**

当明日方舟在启动时意外退出，GUI 界面的开始/结束按钮将卡在加载状态无法控制。这是由于 `MaaToolClient` 会无限期地尝试重新连接到已关闭的应用程序。

以下 Python 程序可用于模拟这种意外退出，它会强制终止进程 (`com.hypergryph.arknights`)：

```
import time
import os

KEYWORD_TO_CLOSE = "com.hypergryph.arknights" 
CHECK_INTERVAL = 0.2

def kill_with_pkill_force(keyword):
    # -i 忽略大小写, -f 匹配全命令行, -9 发送 SIGKILL 强制终止
    command = f'pkill -i -f "{keyword}"'
    
    # os.system(command) 执行命令
    exit_code = os.system(command) 
    
    if exit_code == 0:
        print(f"应用程序 '{keyword}' 被强制关闭 (pkill -9)。")
    else:
        print(f"未检测到应用程序 '{keyword}' 运行。")


def main_pkill_partial():
    print(f"程序启动。正在监控关键词: **{KEYWORD_TO_CLOSE}** (使用 pkill -i -f)")
    print(f"检查间隔: {CHECK_INTERVAL} 秒。")
    print("按 Ctrl+C 停止。")
    
    try:
        while True:
            kill_with_pkill_force(KEYWORD_TO_CLOSE)
            time.sleep(CHECK_INTERVAL)
            
    except KeyboardInterrupt:
        print("\n程序已停止。")

main_pkill_partial()
```

引入重试限制解决了此问题，使客户端能够快速识别失败，并将控制权返回给用户界面。

-----

### **主要更改**

1.  **重试机制的实现：**
      * 在 `MaaToolClient` 的 `init?(address: String)` 方法中，引入了 **`retryCount`** 变量和一个 **`maxRetries`** 常量（设置为 **20**）。
      * 每当连接重试时，**`retryCount`** 都会递增。
2.  **连接中止逻辑：**
      * 如果 `retryCount` 超过 `maxRetries` 限制，当前的 **`NWConnection` 将被取消** (`connection.cancel()`)。
      * 随后，**`MaaToolClient` 的初始化将失败**（返回 `nil`），从而终止无限重试的循环。

-----

### **受影响的文件**

  * `MaaToolClient.swift`