### PR TITLE
Fix typo in yellow ticket store message

### DIFF
--- a/MeoAsstMac/Views/MiniGameView.swift
+++ b/MeoAsstMac/Views/MiniGameView.swift
@@ -136,7 +136,7 @@ enum MiniGameOption: String, CaseIterable {
             NSLocalizedString(
                 """
                 购买寻访凭证。
-                请确保自己只少有258张黄票。
+                请确保自己至少有258张黄票。
                 """, comment: "")
         case .sideStoryStore:
             NSLocalizedString(


### PR DESCRIPTION
黄票商店中的提示信息有错别字“只少”，应为“至少”。