### PR TITLE
fix: 更新次生预案小游戏任务名

### DIFF
--- a/MeoAsstMac/Views/MiniGameView.swift
+++ b/MeoAsstMac/Views/MiniGameView.swift
@@ -61,7 +61,7 @@ enum MiniGameOption: String, CaseIterable {
     var taskName: String {
         switch self {
         case .rebuildingMandate:
-            return "MiniGame@RebuildingMandate@Begin"
+            return "MiniGame@RM-TR-1@Begin"
         case .honeyFruit:
             return "MiniGame@ALL@GreenGrass@DuelChannel@Begin"
         case .greenGrass:


### PR DESCRIPTION
其实现在 WpfGui 的小游戏列表不再完全写死，非常驻活动的小游戏似乎是从 [StageActivityV2.json](https://github.com/MaaAssistantArknights/MaaRelease/commits/main/MaaAssistantArknights/api/gui/StageActivityV2.json) 读取。如果大佬有空的话还请看看。

如果准备直接重构的话就关了这个 PR 好了。

## Summary by Sourcery

Bug Fixes:
- 修正用于“重建任务”小游戏的任务名称，使其与当前标识符保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the task name used for the rebuilding mandate minigame to match the current identifier.

</details>