### PR TITLE
feat: Add WDA (WebDriverAgent) touch mode support

### DIFF
--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -118,6 +118,9 @@ import SwiftUI
                 if touchMode == .MacPlayTools {
                     useAdbLite = false
                     connectionProfile = "CompatMac"
+                } else if touchMode == .WDA {
+                    useAdbLite = false
+                    connectionProfile = "CompatMac"
                 } else {
                     useAdbLite = true
                 }
@@ -227,6 +230,8 @@ extension MAAViewModel {
         logTrace("ConnectingToEmulator")
         if touchMode == .MacPlayTools {
             logTrace("如果长时间连接不上或出错，请尝试下载使用“文件” > “PlayCover链接…”中的最新版本")
+        } else if touchMode == .WDA {
+            logTrace("正在通过 WebDriverAgent 连接，请确保 WDA 已在 iOS 设备上运行")
         }
         try await handle?.connect(adbPath: adbPath, address: connectionAddress, profile: connectionProfile)
         logTrace("Running")
@@ -282,7 +287,7 @@ extension MAAViewModel {
     private func loadResource(url: URL) async throws {
         try await MAAProvider.shared.loadResource(path: url.path)
 
-        if touchMode == .MacPlayTools {
+        if touchMode == .MacPlayTools || touchMode == .WDA {
             let platformResource = url.appendingPathComponent("resource")
                 .appendingPathComponent("platform_diff")
                 .appendingPathComponent("iOS")

--- a/MeoAsstMac/Settings/ConnectionSettingsView.swift
+++ b/MeoAsstMac/Settings/ConnectionSettingsView.swift
@@ -23,6 +23,11 @@ struct ConnectionSettingsView: View {
                     .font(.caption).foregroundStyle(.secondary)
             }
 
+            if viewModel.touchMode == .WDA {
+                Text("使用 WebDriverAgent 连接真实 iOS 设备。请确保 WDA 已在设备上运行（默认端口 8100）。")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+
             HStack {
                 Text("连接地址")
                 TextField("", text: $viewModel.connectionAddress)
@@ -75,4 +80,5 @@ enum MaaTouchMode: String, CaseIterable {
     case minitouch
     case maatouch
     case MacPlayTools
+    case WDA
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -295,22 +295,6 @@
         }
       }
     },
-    "CombatOps" : {
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "스테이지: 일반 작전"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关卡：普通作战"
-          }
-        }
-      }
-    },
     "CDK" : {
       "shouldTranslate" : false
     },
@@ -374,6 +358,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "战斗出错"
+          }
+        }
+      }
+    },
+    "CombatOps" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스테이지: 일반 작전"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关卡：普通作战"
           }
         }
       }
@@ -1999,6 +1999,9 @@
         }
       }
     },
+    "使用 WebDriverAgent 连接真实 iOS 设备。请确保 WDA 已在设备上运行（默认端口 8100）。" : {
+
+    },
     "使用密文板" : {
       "localizations" : {
         "ko" : {
@@ -2801,7 +2804,11 @@
         }
       }
     },
+    "如果长时间连接不上或出错，请尝试下载使用\"文件\" > \"PlayCover链接…\"中的最新版本" : {
+
+    },
     "如果长时间连接不上或出错，请尝试下载使用“文件” > “PlayCover链接…”中的最新版本" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ko" : {
           "stringUnit" : {
@@ -3670,6 +3677,9 @@
           }
         }
       }
+    },
+    "正在通过 WebDriverAgent 连接，请确保 WDA 已在 iOS 设备上运行" : {
+
     },
     "每次执行时最大招募次数: " : {
       "localizations" : {


### PR DESCRIPTION
Add WDA as a new touch mode option for controlling real iOS devices via WebDriverAgent HTTP API.
https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/15406/

## Summary by Sourcery

将 WDA（WebDriverAgent）添加为新的触控模式选项，并将其集成到连接处理和 iOS 特定资源加载中。

新功能：
- 在 `MaaTouchMode` 选项中引入新的 WDA 触控模式，用于通过 WebDriverAgent 连接真实的 iOS 设备。
- 当选择 WDA 模式时，在连接设置界面中显示 WDA 专属的连接引导文案。

增强内容：
- 在视图模型中，使 WDA 的连接配置和 adb 使用方式与现有的 MacPlayTools 模式保持一致。
- 扩展 iOS 特定的平台资源加载逻辑，使其在 WDA 触控模式激活时同样运行。
- 在发起连接时添加 WDA 专属日志，帮助用户确认 WebDriverAgent 已在设备上运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add WDA (WebDriverAgent) as a new touch mode option and integrate it into connection handling and iOS-specific resource loading.

New Features:
- Introduce a new WDA touch mode in the MaaTouchMode selection for connecting to real iOS devices via WebDriverAgent.
- Display WDA-specific connection guidance text in the connection settings UI when WDA mode is selected.

Enhancements:
- Align connection profile and adb usage for WDA with the existing MacPlayTools mode in the view model.
- Extend iOS-specific platform resource loading to also run when WDA touch mode is active.
- Add WDA-specific logging when initiating a connection to help users ensure WebDriverAgent is running on the device.

</details>