### PR TITLE
refactor: 统一使用 String(localized:) 替代 NSLocalizedString

### DIFF
--- a/MeoAsstMac/Configuration Views/RoguelikeSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/RoguelikeSettingsView.swift
@@ -194,17 +194,17 @@ extension RoguelikeConfiguration.Mode {
     var description: String {
         switch self {
         case .exp:
-            NSLocalizedString("刷分/奖励点数，尽可能稳定地打更多层数", comment: "")
+            String(localized: "刷分/奖励点数，尽可能稳定地打更多层数", comment: "")
         case .investment:
-            NSLocalizedString("刷源石锭，到达第二层后直接退出", comment: "")
+            String(localized: "刷源石锭，到达第二层后直接退出", comment: "")
         case .collectible:
-            NSLocalizedString("刷开局，刷取热水壶或精二干员开局", comment: "")
+            String(localized: "刷开局，刷取热水壶或精二干员开局", comment: "")
         case .clpPds:
-            NSLocalizedString("刷坍缩范式，遇到非稀有坍缩范式后重开", comment: "")
+            String(localized: "刷坍缩范式，遇到非稀有坍缩范式后重开", comment: "")
         case .squad:
-            NSLocalizedString("刷月度小队，到达第五层后直接退出", comment: "")
+            String(localized: "刷月度小队，到达第五层后直接退出", comment: "")
         case .exploration:
-            NSLocalizedString("刷深入调查，尽可能稳定地打更多层数", comment: "")
+            String(localized: "刷深入调查，尽可能稳定地打更多层数", comment: "")
         }
     }
 }
@@ -213,15 +213,15 @@ extension RoguelikeConfiguration.Theme: CustomStringConvertible {
     var description: String {
         switch self {
         case .Phantom:
-            return NSLocalizedString("傀影与猩红血钻", comment: "")
+            return String(localized: "傀影与猩红血钻", comment: "")
         case .Mizuki:
-            return NSLocalizedString("水月与深蓝之树", comment: "")
+            return String(localized: "水月与深蓝之树", comment: "")
         case .Sami:
-            return NSLocalizedString("探索者的银凇止境", comment: "")
+            return String(localized: "探索者的银凇止境", comment: "")
         case .Sarkaz:
-            return NSLocalizedString("萨卡兹的无终奇语", comment: "")
+            return String(localized: "萨卡兹的无终奇语", comment: "")
         case .JieGarden:
-            return NSLocalizedString("岁的界园志异", comment: "")
+            return String(localized: "岁的界园志异", comment: "")
         }
     }
 

--- a/MeoAsstMac/Core/MaaMessage.swift
+++ b/MeoAsstMac/Core/MaaMessage.swift
@@ -387,7 +387,7 @@ extension MAAViewModel {
             }
 
             if allDrops.count == 0 {
-                allDrops.append(NSLocalizedString("NoDrop", comment: ""))
+                allDrops.append(String(localized: "NoDrop", comment: ""))
             }
 
             let sanityLeft = self.curSanityBeforeFight - self.sanityCost

--- a/MeoAsstMac/Model/MAATask.swift
+++ b/MeoAsstMac/Model/MAATask.swift
@@ -35,35 +35,35 @@ extension MAATaskType: Codable, CustomStringConvertible {
     var description: String {
         switch self {
         case .StartUp:
-            return NSLocalizedString("开始唤醒", comment: "")
+            return String(localized: "开始唤醒", comment: "")
         case .CloseDown:
-            return NSLocalizedString("关闭游戏", comment: "")
+            return String(localized: "关闭游戏", comment: "")
         case .Recruit:
-            return NSLocalizedString("自动公招", comment: "")
+            return String(localized: "自动公招", comment: "")
         case .Infrast:
-            return NSLocalizedString("基建换班", comment: "")
+            return String(localized: "基建换班", comment: "")
         case .Fight:
-            return NSLocalizedString("刷理智", comment: "")
+            return String(localized: "刷理智", comment: "")
         case .Mall:
-            return NSLocalizedString("收取信用及购物", comment: "")
+            return String(localized: "收取信用及购物", comment: "")
         case .Award:
-            return NSLocalizedString("领取奖励", comment: "")
+            return String(localized: "领取奖励", comment: "")
         case .Roguelike:
-            return NSLocalizedString("自动肉鸽", comment: "")
+            return String(localized: "自动肉鸽", comment: "")
         case .Copilot:
-            return NSLocalizedString("自动抄作业", comment: "")
+            return String(localized: "自动抄作业", comment: "")
         case .SSSCopilot:
-            return NSLocalizedString("自动抄保全作业", comment: "")
+            return String(localized: "自动抄保全作业", comment: "")
         case .Depot:
-            return NSLocalizedString("仓库识别", comment: "")
+            return String(localized: "仓库识别", comment: "")
         case .Reclamation:
-            return NSLocalizedString("生息演算", comment: "")
+            return String(localized: "生息演算", comment: "")
         case .VideoRecognition:
-            return NSLocalizedString("视频识别", comment: "")
+            return String(localized: "视频识别", comment: "")
         case .OperBox:
-            return NSLocalizedString("干员识别", comment: "")
+            return String(localized: "干员识别", comment: "")
         case .Custom:
-            return NSLocalizedString("自定义", comment: "")
+            return String(localized: "自定义", comment: "")
         }
     }
 }

--- a/MeoAsstMac/Navigation/Sidebar.swift
+++ b/MeoAsstMac/Navigation/Sidebar.swift
@@ -71,11 +71,11 @@ extension SidebarEntry: CustomStringConvertible {
     var description: String {
         switch self {
         case .daily:
-            return NSLocalizedString("一键长草", comment: "")
+            return String(localized: "一键长草", comment: "")
         case .copilot:
-            return NSLocalizedString("自动战斗", comment: "")
+            return String(localized: "自动战斗", comment: "")
         case .utility:
-            return NSLocalizedString("实用工具", comment: "")
+            return String(localized: "实用工具", comment: "")
         }
     }
 

--- a/MeoAsstMac/Navigation/UtilityContent.swift
+++ b/MeoAsstMac/Navigation/UtilityContent.swift
@@ -94,17 +94,17 @@ extension UtilityEntry: CustomStringConvertible {
     var description: String {
         switch self {
         case .recruit:
-            return NSLocalizedString("公招词条", comment: "")
+            return String(localized: "公招词条", comment: "")
         case .depot:
-            return NSLocalizedString("仓库材料", comment: "")
+            return String(localized: "仓库材料", comment: "")
         case .oper:
-            return NSLocalizedString("干员列表", comment: "")
+            return String(localized: "干员列表", comment: "")
         case .video:
-            return NSLocalizedString("视频作业", comment: "")
+            return String(localized: "视频作业", comment: "")
         case .gacha:
-            return NSLocalizedString("干员寻访", comment: "")
+            return String(localized: "干员寻访", comment: "")
         case .minigame:
-            return NSLocalizedString("小游戏", comment: "")
+            return String(localized: "小游戏", comment: "")
         }
     }
 

--- a/MeoAsstMac/Settings/ConnectionSettingsView.swift
+++ b/MeoAsstMac/Settings/ConnectionSettingsView.swift
@@ -98,11 +98,11 @@ extension MaaToolsMode: CustomStringConvertible {
     var description: String {
         switch self {
         case .RGBA:
-            NSLocalizedString("默认兼容模式", comment: "")
+            String(localized: "默认兼容模式", comment: "")
         case .BGR:
-            NSLocalizedString("优化加速模式", comment: "")
+            String(localized: "优化加速模式", comment: "")
         case .MacSCK:
-            NSLocalizedString("系统屏幕捕捉", comment: "")
+            String(localized: "系统屏幕捕捉", comment: "")
         }
     }
 }

--- a/MeoAsstMac/Task Configurations/AwardConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/AwardConfiguration.swift
@@ -24,23 +24,23 @@ struct AwardConfiguration: MAATaskConfiguration {
     var subtitle: String {
         var awards = [String]()
         if award {
-            awards.append(NSLocalizedString("日常任务", comment: ""))
-            awards.append(NSLocalizedString("周常任务", comment: ""))
+            awards.append(String(localized: "日常任务", comment: ""))
+            awards.append(String(localized: "周常任务", comment: ""))
         }
         if mail {
-            awards.append(NSLocalizedString("邮件", comment: ""))
+            awards.append(String(localized: "邮件", comment: ""))
         }
         if recruit {
-            awards.append(NSLocalizedString("免费单抽", comment: ""))
+            awards.append(String(localized: "免费单抽", comment: ""))
         }
         if orundum {
-            awards.append(NSLocalizedString("幸运墙", comment: ""))
+            awards.append(String(localized: "幸运墙", comment: ""))
         }
         if mining {
-            awards.append(NSLocalizedString("限时开采许可", comment: ""))
+            awards.append(String(localized: "限时开采许可", comment: ""))
         }
         if specialaccess {
-            awards.append(NSLocalizedString("专享月卡", comment: ""))
+            awards.append(String(localized: "专享月卡", comment: ""))
         }
         return awards.joined(separator: " ")
     }

--- a/MeoAsstMac/Task Configurations/ClosedownConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/ClosedownConfiguration.swift
@@ -17,7 +17,7 @@ struct ClosedownConfiguration: MAATaskConfiguration {
     }
 
     var subtitle: String {
-        NSLocalizedString("请确保这是最后一个任务", comment: "")
+        String(localized: "请确保这是最后一个任务", comment: "")
     }
 
     var summary: String {

--- a/MeoAsstMac/Task Configurations/FightConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/FightConfiguration.swift
@@ -30,7 +30,7 @@ struct FightConfiguration: MAATaskConfiguration {
 
     var subtitle: String {
         if stage == "" {
-            return NSLocalizedString("当前/上次", comment: "")
+            return String(localized: "当前/上次", comment: "")
         } else {
             return stage
         }
@@ -40,15 +40,15 @@ struct FightConfiguration: MAATaskConfiguration {
         var parts = [String]()
 
         if let medicine {
-            parts.append(NSLocalizedString("理智药", comment: "") + "\(medicine)")
+            parts.append(String(localized: "理智药", comment: "") + "\(medicine)")
         }
 
         if let stone {
-            parts.append(NSLocalizedString("源石", comment: "") + "\(stone)")
+            parts.append(String(localized: "源石", comment: "") + "\(stone)")
         }
 
         if let times {
-            parts.append("\(times)" + NSLocalizedString("次", comment: ""))
+            parts.append("\(times)" + String(localized: "次", comment: ""))
         }
 
         return parts.joined(separator: ";")

--- a/MeoAsstMac/Task Configurations/InfrastConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/InfrastConfiguration.swift
@@ -60,25 +60,25 @@ struct InfrastConfiguration: MAATaskConfiguration {
 
     var subtitle: String {
         if mode != .custom {
-            return NSLocalizedString("默认换班", comment: "")
+            return String(localized: "默认换班", comment: "")
         }
 
         if let plan = try? MAAInfrast(path: filename) {
             return plan.title ?? filename
         } else {
-            return NSLocalizedString("无法识别配置", comment: "")
+            return String(localized: "无法识别配置", comment: "")
         }
     }
 
     var summary: String {
         if mode != .custom {
-            return NSLocalizedString("单设施最优解", comment: "")
+            return String(localized: "单设施最优解", comment: "")
         }
 
         if let plan = try? MAAInfrast(path: filename), plan_index < plan.plans.count {
             return plan.plans[plan_index].name ?? "\(plan_index)"
         } else {
-            return NSLocalizedString("未知排班", comment: "")
+            return String(localized: "未知排班", comment: "")
         }
     }
 
@@ -104,23 +104,23 @@ extension InfrastConfiguration.Facility: CustomStringConvertible, Identifiable {
     var description: String {
         switch self {
         case .Mfg:
-            return NSLocalizedString("制造站", comment: "")
+            return String(localized: "制造站", comment: "")
         case .Trade:
-            return NSLocalizedString("贸易站", comment: "")
+            return String(localized: "贸易站", comment: "")
         case .Power:
-            return NSLocalizedString("发电站", comment: "")
+            return String(localized: "发电站", comment: "")
         case .Control:
-            return NSLocalizedString("控制中枢", comment: "")
+            return String(localized: "控制中枢", comment: "")
         case .Reception:
-            return NSLocalizedString("会客室", comment: "")
+            return String(localized: "会客室", comment: "")
         case .Office:
-            return NSLocalizedString("办公室", comment: "")
+            return String(localized: "办公室", comment: "")
         case .Dorm:
-            return NSLocalizedString("宿舍", comment: "")
+            return String(localized: "宿舍", comment: "")
         case .Processing:
-            return NSLocalizedString("加工站", comment: "")
+            return String(localized: "加工站", comment: "")
         case .Training:
-            return NSLocalizedString("训练室", comment: "")
+            return String(localized: "训练室", comment: "")
         }
     }
 }
@@ -129,19 +129,19 @@ extension InfrastConfiguration.DroneUsage: CustomStringConvertible {
     var description: String {
         switch self {
         case .NotUse:
-            return NSLocalizedString("不使用无人机", comment: "")
+            return String(localized: "不使用无人机", comment: "")
         case .Money:
-            return NSLocalizedString("贸易站-龙门币", comment: "")
+            return String(localized: "贸易站-龙门币", comment: "")
         case .SyntheticJade:
-            return NSLocalizedString("贸易站-合成玉", comment: "")
+            return String(localized: "贸易站-合成玉", comment: "")
         case .CombatRecord:
-            return NSLocalizedString("制造站-经验书", comment: "")
+            return String(localized: "制造站-经验书", comment: "")
         case .PureGold:
-            return NSLocalizedString("制造站-赤金", comment: "")
+            return String(localized: "制造站-赤金", comment: "")
         case .OriginStone:
-            return NSLocalizedString("制造站-源石碎片", comment: "")
+            return String(localized: "制造站-源石碎片", comment: "")
         case .Chip:
-            return NSLocalizedString("制造站-芯片组", comment: "")
+            return String(localized: "制造站-芯片组", comment: "")
         }
     }
 }

--- a/MeoAsstMac/Task Configurations/MallConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/MallConfiguration.swift
@@ -23,9 +23,9 @@ struct MallConfiguration: MAATaskConfiguration {
 
     var subtitle: String {
         if shopping {
-            return NSLocalizedString("购物", comment: "")
+            return String(localized: "购物", comment: "")
         } else {
-            return NSLocalizedString("不购物", comment: "")
+            return String(localized: "不购物", comment: "")
         }
     }
 

--- a/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
@@ -20,21 +20,21 @@ struct ReclamationConfiguration: MAATaskConfiguration {
         switch theme {
         case .fire:
             return [
-                0: NSLocalizedString("刷分与建造点", comment: ""),
-                1: NSLocalizedString("刷赤金", comment: ""),
+                0: String(localized: "刷分与建造点", comment: ""),
+                1: String(localized: "刷赤金", comment: ""),
             ]
         case .tales:
             return [
-                0: NSLocalizedString("无存档，通过进出关卡刷生息点数", comment: ""),
-                1: NSLocalizedString("有存档，通过组装支援道具刷生息点数，组装完成后将会跳到下一个量定日并读取前一个量定日的存档", comment: ""),
+                0: String(localized: "无存档，通过进出关卡刷生息点数", comment: ""),
+                1: String(localized: "有存档，通过组装支援道具刷生息点数，组装完成后将会跳到下一个量定日并读取前一个量定日的存档", comment: ""),
             ]
         }
     }
 
     var increment_modes: [Int: String] {
         return [
-            0: NSLocalizedString("点击加号按钮", comment: ""),
-            1: NSLocalizedString("按住加号按钮", comment: ""),
+            0: String(localized: "点击加号按钮", comment: ""),
+            1: String(localized: "按住加号按钮", comment: ""),
         ]
     }
 
@@ -83,9 +83,9 @@ enum ReclamationTheme: String, CaseIterable, Codable, CustomStringConvertible {
     var description: String {
         switch self {
         case .fire:
-            return NSLocalizedString("沙中之火", comment: "")
+            return String(localized: "沙中之火", comment: "")
         case .tales:
-            return NSLocalizedString("沙洲遗闻", comment: "")
+            return String(localized: "沙洲遗闻", comment: "")
         }
     }
 }

--- a/MeoAsstMac/Task Configurations/RecruitConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/RecruitConfiguration.swift
@@ -33,9 +33,9 @@ struct RecruitConfiguration: MAATaskConfiguration {
 
     var subtitle: String {
         if expedite {
-            return NSLocalizedString("加急", comment: "")
+            return String(localized: "加急", comment: "")
         } else {
-            return NSLocalizedString("不加急", comment: "")
+            return String(localized: "不加急", comment: "")
         }
     }
 

--- a/MeoAsstMac/Task Configurations/RoguelikeConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/RoguelikeConfiguration.swift
@@ -210,15 +210,15 @@ extension RoguelikeConfiguration.Theme {
     var shortDescription: String {
         switch self {
         case .Phantom:
-            return NSLocalizedString("傀影", comment: "")
+            return String(localized: "傀影", comment: "")
         case .Mizuki:
-            return NSLocalizedString("水月", comment: "")
+            return String(localized: "水月", comment: "")
         case .Sami:
-            return NSLocalizedString("萨米", comment: "")
+            return String(localized: "萨米", comment: "")
         case .Sarkaz:
-            return NSLocalizedString("萨卡兹", comment: "")
+            return String(localized: "萨卡兹", comment: "")
         case .JieGarden:
-            return NSLocalizedString("界园", comment: "")
+            return String(localized: "界园", comment: "")
         }
     }
 
@@ -236,17 +236,17 @@ extension RoguelikeConfiguration.Mode {
     var shortDescription: String {
         switch self {
         case .exp:
-            NSLocalizedString("优先层数", comment: "")
+            String(localized: "优先层数", comment: "")
         case .investment:
-            NSLocalizedString("优先投资", comment: "")
+            String(localized: "优先投资", comment: "")
         case .collectible:
-            NSLocalizedString("凹开局", comment: "")
+            String(localized: "凹开局", comment: "")
         case .clpPds:
-            NSLocalizedString("刷坍缩", comment: "")
+            String(localized: "刷坍缩", comment: "")
         case .squad:
-            NSLocalizedString("月度小队", comment: "")
+            String(localized: "月度小队", comment: "")
         case .exploration:
-            NSLocalizedString("深入调查", comment: "")
+            String(localized: "深入调查", comment: "")
         }
     }
 }
@@ -265,9 +265,9 @@ extension RoguelikeConfiguration.Difficulty: Codable, CustomStringConvertible {
     var description: String {
         switch self {
         case .max:
-            return NSLocalizedString("最高难度", comment: "")
+            return String(localized: "最高难度", comment: "")
         case .current:
-            return NSLocalizedString("当前难度", comment: "")
+            return String(localized: "当前难度", comment: "")
         default:
             return "难度\(id)"
         }

--- a/MeoAsstMac/Task Configurations/StartupConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/StartupConfiguration.swift
@@ -23,7 +23,7 @@ struct StartupConfiguration: MAATaskConfiguration {
     }
 
     var summary: String {
-        let startGame = start_game_enabled ? NSLocalizedString("自动启动", comment: "") : ""
+        let startGame = start_game_enabled ? String(localized: "自动启动", comment: "") : ""
         return "\(account_name) \(startGame)"
     }
 
@@ -58,17 +58,17 @@ enum MAAClientChannel: String, Codable, CaseIterable, CustomStringConvertible {
     var description: String {
         switch self {
         case .Official:
-            return NSLocalizedString("官服", comment: "")
+            return String(localized: "官服", comment: "")
         case .Bilibili:
-            return NSLocalizedString("Bilibili服", comment: "")
+            return String(localized: "Bilibili服", comment: "")
         case .YoStarEN:
-            return NSLocalizedString("国际服（YoStarEN）", comment: "")
+            return String(localized: "国际服（YoStarEN）", comment: "")
         case .YoStarJP:
-            return NSLocalizedString("日服（YoStarJP）", comment: "")
+            return String(localized: "日服（YoStarJP）", comment: "")
         case .YoStarKR:
-            return NSLocalizedString("韩服（YoStarKR）", comment: "")
+            return String(localized: "韩服（YoStarKR）", comment: "")
         case .txwy:
-            return NSLocalizedString("繁中服（txwy）", comment: "")
+            return String(localized: "繁中服（txwy）", comment: "")
         }
     }
 

--- a/MeoAsstMac/Utils/ResourceUpdater.swift
+++ b/MeoAsstMac/Utils/ResourceUpdater.swift
@@ -23,9 +23,9 @@ extension MAAResourceChannel: CustomStringConvertible {
     public var description: String {
         switch self {
         case .github:
-            return NSLocalizedString("GitHub", comment: "")
+            return String(localized: "GitHub", comment: "")
         case .mirrorChyan:
-            return NSLocalizedString("MirrorChyan", comment: "")
+            return String(localized: "MirrorChyan", comment: "")
         }
     }
 }
@@ -34,13 +34,13 @@ extension MAAResourceChannel.Error: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .emptyURL:
-            return NSLocalizedString("无下载链接，请检查CDK", comment: "")
+            return String(localized: "无下载链接，请检查CDK", comment: "")
         case .noNeedUpdate:
-            return NSLocalizedString("无需更新", comment: "")
+            return String(localized: "无需更新", comment: "")
         case .forbidden:
-            return NSLocalizedString("访问被禁止，请检查IP或CDK", comment: "")
+            return String(localized: "访问被禁止，请检查IP或CDK", comment: "")
         case .rateExceeded:
-            return NSLocalizedString("IP请求频率过快，请稍后再试", comment: "")
+            return String(localized: "IP请求频率过快，请稍后再试", comment: "")
         }
     }
 }

--- a/MeoAsstMac/Views/MiniGameView.swift
+++ b/MeoAsstMac/Views/MiniGameView.swift
@@ -88,39 +88,39 @@ enum MiniGameOption: String, CaseIterable {
     var displayName: String {
         switch self {
         case .rebuildingMandate:
-            return NSLocalizedString("RM-次生预案", comment: "")
+            return String(localized: "RM-次生预案", comment: "")
         case .honeyFruit:
-            return NSLocalizedString("争锋频道：蜜果城", comment: "")
+            return String(localized: "争锋频道：蜜果城", comment: "")
         case .greenGrass:
-            return NSLocalizedString("争锋频道：青草城", comment: "")
+            return String(localized: "争锋频道：青草城", comment: "")
         case .atConversationRoom:
-            return NSLocalizedString("AT-相谈室", comment: "")
+            return String(localized: "AT-相谈室", comment: "")
         case .greenTicketStore:
-            return NSLocalizedString("绿票商店", comment: "")
+            return String(localized: "绿票商店", comment: "")
         case .yellowTickerStore:
-            return NSLocalizedString("黄票商店", comment: "")
+            return String(localized: "黄票商店", comment: "")
         case .sideStoryStore:
-            return NSLocalizedString("活动商店", comment: "")
+            return String(localized: "活动商店", comment: "")
         case .reclamationStore:
-            return NSLocalizedString("生息演算商店", comment: "")
+            return String(localized: "生息演算商店", comment: "")
         case .osKarlanTradeTechnology:
-            return NSLocalizedString("OS-喀兰贸易技术研发部", comment: "")
+            return String(localized: "OS-喀兰贸易技术研发部", comment: "")
         case .pvFireworksOrganizingCommittee:
-            return NSLocalizedString("PV-烟花筹委会", comment: "")
+            return String(localized: "PV-烟花筹委会", comment: "")
         case .strongholdProtocolAlliance:
-            return NSLocalizedString("卫戍协议：盟约", comment: "")
+            return String(localized: "卫戍协议：盟约", comment: "")
         }
     }
 
     var instructions: String {
         switch self {
         case .rebuildingMandate:
-            NSLocalizedString(
+            String(localized:
                 """
                 过完新手教程后进入前哨支点，滑动到界面最左侧。
                 """, comment: "")
         case .honeyFruit:
-            NSLocalizedString(
+            String(localized:
                 """
                 手动跳过教程对话，然后可以直接退出。
                 在活动主界面（右下角有“加入赛事”处）开始任务。
@@ -128,7 +128,7 @@ enum MiniGameOption: String, CaseIterable {
                 跟着鸭总喝口汤。
                 """, comment: "")
         case .greenGrass:
-            NSLocalizedString(
+            String(localized:
                 """
                 手动跳过教程对话，然后可以直接退出。
                 在活动主界面（右下角有“加入赛事”处）开始任务。
@@ -136,46 +136,46 @@ enum MiniGameOption: String, CaseIterable {
                 跟着鸭总喝口汤。
                 """, comment: "")
         case .atConversationRoom:
-            NSLocalizedString(
+            String(localized:
                 """
                 在活动主界面（右下角有“开始营业/继续营业”处）开始任务。
                 等待自动完成相谈室对话。
                 """, comment: "")
         case .greenTicketStore:
-            NSLocalizedString(
+            String(localized:
                 """
                 1层全买。
                 2层买寻访凭证和招聘许可。
                 """, comment: "")
         case .yellowTickerStore:
-            NSLocalizedString(
+            String(localized:
                 """
                 购买寻访凭证。
                 请确保自己至少有258张黄票。
                 """, comment: "")
         case .sideStoryStore:
-            NSLocalizedString(
+            String(localized:
                 """
                 请在活动商店页面开始。
                 不买无限池。
                 """, comment: "")
         case .reclamationStore:
-            NSLocalizedString(
+            String(localized:
                 """
                 请在活动商店页面开始。
                 """, comment: "")
         case .osKarlanTradeTechnology:
-            NSLocalizedString(
+            String(localized:
                 """
                 在活动主界面（右下角有“开始重建”处）开始任务。
                 """, comment: "")
         case .pvFireworksOrganizingCommittee:
-            NSLocalizedString(
+            String(localized:
                 """
                 在活动页面最左侧开始
                 """, comment: "")
         case .strongholdProtocolAlliance:
-            NSLocalizedString(
+            String(localized:
                 """
                 在活动主界面（有“独立模拟”处开始任务）
                 手动通关“标准模拟”可以更快的刷分

--- a/MeoAsstMac/Views/ResourceUpdateView.swift
+++ b/MeoAsstMac/Views/ResourceUpdateView.swift
@@ -90,7 +90,7 @@ struct ResourceUpdateView: View {
         try? FileManager.default.removeItem(at: localURL)
         for try await progress in URLSession.shared.downloadTo(localURL, from: remoteURL) {
             try Task.checkCancellation()
-            self.progress = (NSLocalizedString("正在下载…", comment: ""), progress.fractionCompleted)
+            self.progress = (String(localized: "正在下载…", comment: ""), progress.fractionCompleted)
         }
     }
 
@@ -98,7 +98,7 @@ struct ResourceUpdateView: View {
         removeExtracts()
         for try await progress in FileManager.default.unzipItemAt(localURL, to: tmpURL) {
             try Task.checkCancellation()
-            self.progress = (NSLocalizedString("正在解压…", comment: ""), progress.fractionCompleted)
+            self.progress = (String(localized: "正在解压…", comment: ""), progress.fractionCompleted)
         }
     }
 


### PR DESCRIPTION
项目里两种本地化 API 混用：代码里已有 21 处 `String(localized:)`，另 133 处还是老的 `NSLocalizedString`。统一到新 API。

`Resources/Localizable.xcstrings` 已经是 String Catalog 格式，配合新 API 才能让 Xcode 在编译时自动扫源码提取字符串。用 `NSLocalizedString` 调用扫不到，key 得手动维护。

## 改动

- 18 文件，+133 / -133，纯机械替换
- 所有调用都是标准两参数形式 `(text, comment:)`，没有 `tableName:`/`bundle:`/`value:` 等变体
- `Resources/Localizable.xcstrings` 不动，现有 450 key（zh-Hans / ko）原样保留

## 验证

`xcodebuild -project MeoAsstMac.xcodeproj -scheme MAA -configuration Debug build` 本地通过，0 warning 0 error。

## Summary by Sourcery

增强内容：
- 将各视图、配置、导航和工具中的剩余 `NSLocalizedString` 用于面向用户的字符串，替换为 `String(localized:comment:)`，以与现有的 String Catalog 设置保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace remaining NSLocalizedString usages with String(localized:comment:) in user-facing strings across views, configurations, navigation, and utilities to align with the existing String Catalog setup.

</details>