### PR TITLE
fix: 仓库材料识别不显示结果

### DIFF
--- a/MeoAsstMac/Model/MAADepot.swift
+++ b/MeoAsstMac/Model/MAADepot.swift
@@ -9,38 +9,66 @@ import Foundation
 
 struct MAADepot: Codable {
     let done: Bool
-    let arkplanner: Arkplanner
-    let lolicon: Lolicon
-    
-    struct Arkplanner: Codable {
-        let object: ArkplannerObject
-        let data: String
-    }
-    
-    struct ArkplannerObject: Codable {
-        let items: [ArkplannerItem]
-    }
-    
-    struct ArkplannerItem: Codable {
-        let id: String
-        let have: Int
-        let name: String
-    }
-    
-    struct Lolicon: Codable {
-        let object: [String: Int]
-        let data: String
-    }
+    let data: String
 }
 
 extension MAADepot: CustomStringConvertible {
     var contents: [String] {
-        arkplanner.object.items
-            .sorted { $0.id < $1.id }
-            .map { "\($0.name): \($0.have)" }
+        do {
+            let depot = try JSONDecoder().decode([String: Int].self, from: Data(data.utf8))
+            return depot
+                .sorted { $0.key < $1.key }
+                .map { "\(MAADepot.arkItems[$0.key]?.name ?? $0.key): \($0.value)" }
+        } catch {
+            return []
+        }
     }
-    
+
     var description: String {
         contents.joined(separator: "\n")
+    }
+
+    private static let arkItems: [String: DropItem] = {
+        guard let url = Bundle.main.resourceURL?
+            .appendingPathComponent("resource")
+            .appendingPathComponent("item_index.json"),
+            let data = try? Data(contentsOf: url),
+            let json = try? JSONDecoder().decode([String: DropItem].self, from: data)
+        else {
+            return [:]
+        }
+        return json
+    }()
+
+    var arkPlannerExportText: String {
+        do {
+            let depot = try JSONDecoder().decode([String: Int].self, from: Data(data.utf8))
+            let items = depot
+                .filter { $0.value > 0 }
+                .compactMap { entry -> [String: Any]? in
+                    guard let item = MAADepot.arkItems[entry.key] else { return nil }
+                    return ["id": entry.key, "have": entry.value, "name": item.name]
+                }
+            let export: [String: Any] = [
+                "@type": "@penguin-statistics/depot",
+                "items": items
+            ]
+            return try String(data: JSONSerialization.data(withJSONObject: export), encoding: .utf8) ?? ""
+        } catch {
+            return ""
+        }
+    }
+
+    var loliconExportText: String {
+        do {
+            let depot = try JSONDecoder().decode([String: Int].self, from: Data(data.utf8))
+            var export: [String: Int] = [:]
+            depot
+                .filter { $0.value > 0 }
+                .forEach { export[$0.key] = $0.value }
+            return try String(data: JSONSerialization.data(withJSONObject: export), encoding: .utf8) ?? ""
+        } catch {
+            return ""
+        }
     }
 }

--- a/MeoAsstMac/Views/DepotView.swift
+++ b/MeoAsstMac/Views/DepotView.swift
@@ -21,11 +21,11 @@ struct DepotView: View {
                 Text("复制结果JSON至剪贴板：")
 
                 Button("企鹅物流") {
-                    copyToPasteboard(text: viewModel.depot?.arkplanner.data)
+                    copyToPasteboard(text: viewModel.depot?.arkPlannerExportText)
                     NSWorkspace.shared.open(URL(string: "https://penguin-stats.cn/planner")!)
                 }
                 Button("明日方舟工具箱") {
-                    copyToPasteboard(text: viewModel.depot?.lolicon.data)
+                    copyToPasteboard(text: viewModel.depot?.loliconExportText)
                     NSWorkspace.shared.open(URL(string: "https://arkntools.app/#/material")!)
                 }
             }


### PR DESCRIPTION
修复因 https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/15358 仓库识别结构变更导致仓库材料识别不显示结果

fix #82

## Summary by Sourcery

更新仓库（depot）模型和导出方式，以适配新的后端结构，并恢复材料识别输出。

Bug 修复：
- 修复后端结构变更后，仓库材料识别结果不再显示的问题。

增强内容：
- 将 `MAADepot` 数据结构简化为扁平的 JSON 字符串，并在需要时从中派生 `arkplanner` / `lolicon` 导出数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update depot model and exports to align with new backend structure and restore material recognition output.

Bug Fixes:
- Fix depot material recognition not displaying results after backend structure changes.

Enhancements:
- Simplify MAADepot data structure to a flat JSON string and derive arkplanner/lolicon exports on demand from it.

</details>