### PR TITLE
fix(macOS): 为生息演算重启锚点添加 RA-4 入口

### DIFF
--- a/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift
@@ -32,6 +32,7 @@ struct ReclamationConfiguration: MAATaskConfiguration {
             return [
                 1 << 4: String(localized: "RA-1"),
                 2 << 4: String(localized: "RA-15"),
+                3 << 4: String(localized: "RA-4"),
             ]
         }
     }


### PR DESCRIPTION
## 修改内容

为 macOS GUI 的生息演算 `Reclamation / RelaunchAnchor` 配置补充 RA-4 入口。

修改文件：

```text

src/MaaMacGui/MeoAsstMac/Task Configurations/ReclamationConfiguration.swift

```

新增选项：

```swift

3 << 4: String(localized: "RA-4"),

```

## Summary by Sourcery

New Features:
- 为 macOS GUI 的 Reclamation/RelaunchAnchor 选项中新增 RA-4 条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce an RA-4 entry in the Reclamation/RelaunchAnchor options for the macOS GUI.

</details>