### PR TITLE
feat: 支持作业集，批量作战（支持自动编队和信赖干员）

### DIFF
--- a/MeoAsstMac/Model/MAACopilot.swift
+++ b/MeoAsstMac/Model/MAACopilot.swift
@@ -13,6 +13,7 @@ struct MAACopilot: Codable, Equatable {
     let groups: [Group]?
     let minimum_required: String
     let doc: Documentation?
+    let difficulty: Int?
 
     // MARK: SSS
 
@@ -36,6 +37,10 @@ struct MAACopilot: Codable, Equatable {
         let title_color: String?
         let details: String?
         let details_color: String?
+    }
+
+    var isRaid: Bool {
+        difficulty == 2
     }
 }
 

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -92,7 +92,12 @@ import SwiftUI
     }
 
     @Published var copilot: CopilotConfiguration?
+    @Published var copilotFormation = false
+    @Published var copilotAddTrust = false
+    @Published var useCopilotSet = false
+    @Published var copilotSetEntries = [CopilotSetTaskEntry]()
     @Published var downloadCopilot: String?
+    @Published var downloadCopilotSet: String?
     @Published var showImportCopilot = false
     @Published var copilotDetailMode: CopilotDetailMode = .log
 
@@ -518,7 +523,9 @@ extension MAAViewModel {
         defer { handleEarlyReturn(backTo: .idle) }
 
         guard let copilot,
-            let params = copilot.params
+            let params = copilot
+                .applyingCommonOptions(formation: copilotFormation, addTrust: copilotAddTrust)
+                .params
         else {
             return
         }
@@ -526,7 +533,7 @@ extension MAAViewModel {
         try await ensureHandle()
 
         switch copilot {
-        case .regular:
+        case .regular, .regularList:
             _ = try await handle?.appendTask(type: .Copilot, params: params)
         case .sss:
             _ = try await handle?.appendTask(type: .SSSCopilot, params: params)

--- a/MeoAsstMac/Navigation/CopilotContent.swift
+++ b/MeoAsstMac/Navigation/CopilotContent.swift
@@ -14,9 +14,32 @@ struct CopilotContent: View {
     @State private var copilots = Set<URL>()
     @State private var downloading = false
     @State private var expanded = false
+    @State private var copilotSetExpanded = true
 
     var body: some View {
         List(selection: $selection) {
+            DisclosureGroup(isExpanded: $copilotSetExpanded) {
+                ForEach(viewModel.copilotSetEntries) { entry in
+                    CopilotListRow(
+                        title: entry.displayName,
+                        onSelect: { selectCopilot(url: URL(fileURLWithPath: entry.filename)) },
+                        removalTitle: "移出作业集",
+                        onRemove: { removeCopilotSetEntry(entry) })
+                }
+            } label: {
+                Text("作业集")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        withAnimation {
+                            copilotSetExpanded.toggle()
+                        }
+                    }
+            }
+
             DisclosureGroup(isExpanded: $expanded) {
                 ForEach(bundledCopilots, id: \.self) { url in
                     Text(url.lastPathComponent)
@@ -51,11 +74,14 @@ struct CopilotContent: View {
         }
         .toolbar(content: listToolbar)
         .animation(.default, value: copilots)
+        .animation(.default, value: viewModel.copilotSetEntries)
+        .animation(.default, value: viewModel.useCopilotSet)
         .animation(.default, value: downloading)
         .onAppear(perform: loadUserCopilots)
         .onDrop(of: [.fileURL], isTargeted: .none, perform: addCopilots)
         .onReceive(viewModel.$copilotDetailMode, perform: deselectCopilot)
         .onReceive(viewModel.$downloadCopilot, perform: downloadCopilot)
+        .onReceive(viewModel.$downloadCopilotSet, perform: downloadCopilotSet)
         .onReceive(viewModel.$videoRecoginition, perform: selectNewCopilot)
         .fileImporter(
             isPresented: $viewModel.showImportCopilot,
@@ -108,6 +134,10 @@ struct CopilotContent: View {
     private func start() {
         Task {
             viewModel.copilotDetailMode = .log
+            if viewModel.useCopilotSet {
+                guard !viewModel.copilotSetEntries.isEmpty else { return }
+                viewModel.copilot = .regularList(makeCopilotListConfiguration())
+            }
             try await viewModel.startCopilot()
         }
     }
@@ -145,22 +175,74 @@ struct CopilotContent: View {
     private func downloadCopilot(id: String?) {
         guard let id else { return }
 
-        let file =
-            externalDirectory
-            .appendingPathComponent(id)
-            .appendingPathExtension("json")
-
-        let url = URL(string: "https://prts.maa.plus/copilot/get/\(id)")!
         Task {
             self.downloading = true
             do {
-                let data = try await URLSession.shared.data(from: url).0
-                let response = try JSONDecoder().decode(CopilotResponse.self, from: data)
-                try response.data.content.write(toFile: file.path, atomically: true, encoding: .utf8)
+                let file = externalDirectory.appendingPathComponent(id).appendingPathExtension("json")
+                let content = try await requestCopilotContent(id: id)
+                try content.write(toFile: file.path, atomically: true, encoding: .utf8)
                 copilots.insert(file)
                 self.selection = file
             } catch {
-                print(error)
+                viewModel.logError("下载作业失败: \(id)")
+                viewModel.logError("\(error.localizedDescription)")
+            }
+            self.downloading = false
+        }
+    }
+
+    private func downloadCopilotSet(id: String?) {
+        guard let id else { return }
+
+        Task {
+            self.downloading = true
+            do {
+                let response = try await requestCopilotSet(id: id)
+                guard response.statusCode == 200 else {
+                    if let message = response.message {
+                        viewModel.logError("\(message)")
+                    } else {
+                        viewModel.logError("作业集不存在: \(id)")
+                    }
+                    self.downloading = false
+                    return
+                }
+
+                guard let copilotIds = response.data?.copilotIds, !copilotIds.isEmpty else {
+                    viewModel.logError("作业集为空: \(id)")
+                    self.downloading = false
+                    return
+                }
+
+                var importedFiles = [URL]()
+                var copilotSetEntries = [CopilotSetTaskEntry]()
+                let fileNames = copilotSetImportFileNames(copilotIDs: copilotIds)
+
+                for (copilotId, fileName) in zip(copilotIds, fileNames) {
+                    do {
+                        let file = externalDirectory.appendingPathComponent(fileName)
+                        let content = try await requestCopilotContent(id: String(copilotId))
+                        try content.write(toFile: file.path, atomically: true, encoding: .utf8)
+                        copilots.insert(file)
+                        importedFiles.append(file)
+                        if let entries = makeCopilotSetEntries(file: file, content: content, copilotID: copilotId) {
+                            copilotSetEntries.append(contentsOf: entries)
+                        }
+                    } catch {
+                        viewModel.logError("下载作业集条目失败: \(copilotId)")
+                    }
+                }
+
+                if importedFiles.isEmpty {
+                    viewModel.logError("作业集导入失败: \(id)")
+                } else {
+                    viewModel.copilotSetEntries = copilotSetEntries
+                    viewModel.useCopilotSet = !copilotSetEntries.isEmpty
+                    self.selection = importedFiles.first
+                }
+            } catch {
+                viewModel.logError("下载作业集失败: \(id)")
+                viewModel.logError("\(error.localizedDescription)")
             }
             self.downloading = false
         }
@@ -168,6 +250,7 @@ struct CopilotContent: View {
 
     private func deleteCopilot(url: URL) {
         copilots.remove(url)
+        removeCopilotSetEntries(filename: url.path)
         guard canDelete(url) else { return }
         try? FileManager.default.removeItem(at: url)
     }
@@ -176,12 +259,31 @@ struct CopilotContent: View {
         guard let selection, let index = copilots.urls.firstIndex(of: selection) else { return }
 
         deleteCopilot(url: selection)
+        selectCopilotAfterDeletion(deletedIndex: index)
+    }
+
+    private func deleteCopilotAndSelectNext(url: URL) {
+        guard let index = copilots.urls.firstIndex(of: url) else {
+            deleteCopilot(url: url)
+            if selection == url {
+                selectCopilot(url: nil)
+            }
+            return
+        }
+
+        deleteCopilot(url: url)
+        if selection == url {
+            selectCopilotAfterDeletion(deletedIndex: index)
+        }
+    }
+
+    private func selectCopilotAfterDeletion(deletedIndex index: Int) {
 
         let urls = copilots.urls
         if index < urls.count {
-            self.selection = urls[index]
+            selectCopilot(url: urls[index])
         } else {
-            self.selection = urls.last
+            selectCopilot(url: urls.last)
         }
     }
 
@@ -194,8 +296,46 @@ struct CopilotContent: View {
     private func selectNewCopilot(url: URL?) {
         if let url {
             copilots.insert(url)
-            selection = copilots.urls.last
+            selectCopilot(url: copilots.urls.last)
         }
+    }
+
+    private func selectCopilot(url: URL?) {
+        selection = url
+        if url != nil {
+            viewModel.copilotDetailMode = .copilotConfig
+        }
+    }
+
+    private func removeCopilotSetEntry(_ entry: CopilotSetTaskEntry) {
+        viewModel.copilotSetEntries.removeAll { $0.id == entry.id }
+        if viewModel.copilotSetEntries.isEmpty {
+            viewModel.useCopilotSet = false
+        }
+    }
+
+    private func removeCopilotSetEntries(filename: String) {
+        viewModel.copilotSetEntries.removeAll { $0.filename == filename }
+        if viewModel.copilotSetEntries.isEmpty {
+            viewModel.useCopilotSet = false
+        }
+    }
+
+    private func makeCopilotListConfiguration() -> RegularCopilotListConfiguration {
+        let list = viewModel.copilotSetEntries.map {
+            CopilotListItem(filename: $0.filename, stage_name: $0.stageName, is_raid: $0.isRaid)
+        }
+        let regularConfig: RegularCopilotConfiguration? = {
+            if case .regular(let config) = viewModel.copilot {
+                return config
+            }
+            return nil
+        }()
+
+        return .init(
+            copilot_list: list,
+            formation: regularConfig?.formation ?? false,
+            add_trust: regularConfig?.add_trust ?? false)
     }
 
     // MARK: - State Wrappers
@@ -246,6 +386,50 @@ struct CopilotContent: View {
             .appendingPathComponent("cache")
             .appendingPathComponent("CombatRecord")
     }
+
+    private func requestCopilotContent(id: String) async throws -> String {
+        let url = URL(string: "https://prts.maa.plus/copilot/get/\(id)")!
+        let data = try await URLSession.shared.data(from: url).0
+        let response = try JSONDecoder().decode(CopilotResponse.self, from: data)
+        return response.data.content
+    }
+
+    private func requestCopilotSet(id: String) async throws -> CopilotSetResponse {
+        let url = URL(string: "https://prts.maa.plus/set/get?id=\(id)")!
+        let data = try await URLSession.shared.data(from: url).0
+        return try JSONDecoder().decode(CopilotSetResponse.self, from: data)
+    }
+
+    private func makeCopilotSetEntries(file: URL, content: String, copilotID: Int) -> [CopilotSetTaskEntry]? {
+        guard
+            let data = content.data(using: .utf8),
+            let copilot = try? JSONDecoder().decode(MAACopilot.self, from: data)
+        else {
+            viewModel.logError("作业集条目解析失败: \(copilotID)")
+            return nil
+        }
+
+        guard copilot.type != "SSS" else {
+            viewModel.logWarn("作业集列表暂不支持保全作业: \(copilotID)")
+            return nil
+        }
+
+        let stageName = StageNavigationNameResolver.resolve(
+            stageName: copilot.stage_name,
+            title: copilot.doc?.title)
+        return copilotSetTaskEntries(filename: file.path, stageName: stageName, difficulty: copilot.difficulty)
+    }
+}
+
+struct CopilotSetTaskEntry: Equatable, Identifiable {
+    let id = UUID()
+    var filename: String
+    var stageName: String
+    var isRaid: Bool
+
+    var displayName: String {
+        isRaid ? "\(stageName)-Adverse" : stageName
+    }
 }
 
 struct CopilotContent_Previews: PreviewProvider {
@@ -255,7 +439,110 @@ struct CopilotContent_Previews: PreviewProvider {
     }
 }
 
+private struct CopilotListRow: View {
+    let title: String
+    var onSelect: () -> Void
+    var removalTitle: String?
+    var onRemove: (() -> Void)?
+
+    var body: some View {
+        Button(action: onSelect) {
+            Text(title)
+                .lineLimit(1)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            if let removalTitle, let onRemove {
+                Button(removalTitle, action: onRemove)
+            }
+        }
+    }
+}
+
 // MARK: - Value Extensions
+
+private func copilotSetImportFileNames(copilotIDs: [Int]) -> [String] {
+    let width = max(2, String(copilotIDs.count).count)
+    return copilotIDs.enumerated().map { index, copilotID in
+        "\(String(format: "%0*d", width, index + 1))_\(copilotID).json"
+    }
+}
+
+private func copilotSetTaskEntries(filename: String, stageName: String, difficulty: Int?) -> [CopilotSetTaskEntry] {
+    let difficulty = difficulty ?? 0
+    let supportsNormal = difficulty == 0 || difficulty & 1 != 0
+    let supportsRaid = difficulty & 2 != 0
+
+    var entries = [CopilotSetTaskEntry]()
+    if supportsNormal {
+        entries.append(.init(filename: filename, stageName: stageName, isRaid: false))
+    }
+    if supportsRaid {
+        entries.append(.init(filename: filename, stageName: stageName, isRaid: true))
+    }
+    return entries
+}
+
+private enum StageNavigationNameResolver {
+    private static let stageCodeByIdentifier: [String: String] = {
+        let url = Bundle.main.resourceURL?
+            .appendingPathComponent("resource")
+            .appendingPathComponent("Arknights-Tile-Pos")
+            .appendingPathComponent("overview")
+            .appendingPathExtension("json")
+
+        guard
+            let url,
+            let data = try? Data(contentsOf: url),
+            let overview = try? JSONDecoder().decode([String: StageOverview].self, from: data)
+        else { return [:] }
+
+        var result = [String: String]()
+        for (_, stage) in overview {
+            guard let code = stage.code else { continue }
+            for identifier in [stage.code, stage.name, stage.stageId, stage.levelId].compactMap({ $0 }) {
+                result[identifier] = code
+            }
+        }
+        return result
+    }()
+
+    static func resolve(stageName: String, title: String?) -> String {
+        if let code = stageCodeByIdentifier[stageName] {
+            return code
+        }
+
+        if let title, let code = extractStageCode(from: title) {
+            return code
+        }
+
+        return stageName
+    }
+
+    private static func extractStageCode(from title: String) -> String? {
+        let pattern = #"(?:[A-Za-z]{0,3})(?:\d{0,2})-(?:(?:A|B|C|D|EX|S|TR|MO)-?)?(?:\d{1,2})"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return nil
+        }
+
+        let range = NSRange(title.startIndex..<title.endIndex, in: title)
+        guard
+            let match = regex.firstMatch(in: title, range: range),
+            let matchRange = Range(match.range, in: title)
+        else { return nil }
+
+        return String(title[matchRange])
+    }
+
+    private struct StageOverview: Decodable {
+        let code: String?
+        let name: String?
+        let stageId: String?
+        let levelId: String?
+    }
+}
 
 extension URL {
     fileprivate var copilots: [URL] {
@@ -287,6 +574,26 @@ private struct CopilotResponse: Codable {
 
     struct CopilotData: Codable {
         let content: String
+    }
+}
+
+private struct CopilotSetResponse: Codable {
+    let statusCode: Int
+    let message: String?
+    let data: CopilotSetData?
+
+    enum CodingKeys: String, CodingKey {
+        case statusCode = "status_code"
+        case message
+        case data
+    }
+
+    struct CopilotSetData: Codable {
+        let copilotIds: [Int]
+
+        enum CodingKeys: String, CodingKey {
+            case copilotIds = "copilot_ids"
+        }
     }
 }
 

--- a/MeoAsstMac/Navigation/CopilotDetail.swift
+++ b/MeoAsstMac/Navigation/CopilotDetail.swift
@@ -14,8 +14,12 @@ struct CopilotDetail: View {
     let url: URL?
 
     var body: some View {
-        VStack {
-            if let url {
+        VStack(spacing: 20) {
+            commonCopilotConfiguration()
+
+            Divider()
+
+            if let url, viewModel.copilotDetailMode == .copilotConfig {
                 CopilotView(url: url)
             } else {
                 LogView()
@@ -26,6 +30,15 @@ struct CopilotDetail: View {
     }
 
     // MARK: - Toolbar
+
+    private func commonCopilotConfiguration() -> some View {
+        HStack {
+            Toggle("自动编队", isOn: $viewModel.copilotFormation)
+            Toggle("信赖干员", isOn: $viewModel.copilotAddTrust)
+            Toggle("使用作业集", isOn: $viewModel.useCopilotSet)
+                .disabled(viewModel.copilotSetEntries.isEmpty)
+        }
+    }
 
     @ToolbarContentBuilder private func detailToolbar() -> some ToolbarContent {
         ToolbarItemGroup {
@@ -74,12 +87,20 @@ struct CopilotDetail: View {
             .disabled(prtsCode.parsedID == nil)
 
             Button {
+                viewModel.downloadCopilotSet = prtsCode.parsedID
+                showAdd = false
+            } label: {
+                Label("添加作业集", systemImage: "square.stack.3d.down.right")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .disabled(prtsCode.parsedID == nil)
+
+            Button {
                 if let clipboardString = NSPasteboard.general.string(forType: .string),
-                    let parsedID = clipboardString.parsedID
+                    clipboardString.parsedID != nil
                 {
                     prtsCode = clipboardString
-                    viewModel.downloadCopilot = parsedID
-                    showAdd = false
                 }
             } label: {
                 Label("从剪贴板读取", systemImage: "doc.on.clipboard")

--- a/MeoAsstMac/Task Configurations/CopilotConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/CopilotConfiguration.swift
@@ -14,6 +14,19 @@ struct RegularCopilotConfiguration: Codable {
     var add_trust = false
 }
 
+struct RegularCopilotListConfiguration: Codable {
+    var enable = true
+    var copilot_list: [CopilotListItem]
+    var formation = false
+    var add_trust = false
+}
+
+struct CopilotListItem: Codable, Equatable {
+    var filename: String
+    var stage_name: String
+    var is_raid = false
+}
+
 struct SSSCopilotConfiguration: Codable {
     var enable = true
     var filename: String
@@ -31,14 +44,32 @@ struct VideoRecognitionConfiguration: Codable {
 
 enum CopilotConfiguration {
     case regular(RegularCopilotConfiguration)
+    case regularList(RegularCopilotListConfiguration)
     case sss(SSSCopilotConfiguration)
 
     var params: String? {
         switch self {
         case .regular(let config):
             return try? config.jsonString()
+        case .regularList(let config):
+            return try? config.jsonString()
         case .sss(let config):
             return try? config.jsonString()
+        }
+    }
+
+    func applyingCommonOptions(formation: Bool, addTrust: Bool) -> Self {
+        switch self {
+        case .regular(var config):
+            config.formation = formation
+            config.add_trust = addTrust
+            return .regular(config)
+        case .regularList(var config):
+            config.formation = formation
+            config.add_trust = addTrust
+            return .regularList(config)
+        case .sss:
+            return self
         }
     }
 }

--- a/MeoAsstMac/Views/CopilotView.swift
+++ b/MeoAsstMac/Views/CopilotView.swift
@@ -45,16 +45,8 @@ struct CopilotView: View {
 
     @ViewBuilder private func pilotConfiguration() -> some View {
         switch viewModel.copilot {
-        case .regular(let innerConfig):
-            let binding = Binding<RegularCopilotConfiguration> {
-                innerConfig
-            } set: { newValue in
-                viewModel.copilot = .regular(newValue)
-            }
-            HStack {
-                Toggle("自动编队", isOn: binding.formation)
-                Toggle("信赖干员", isOn: binding.add_trust)
-            }
+        case .regular, .regularList:
+            EmptyView()
 
         case .sss(let innerConfig):
             let binding = Binding<SSSCopilotConfiguration> {


### PR DESCRIPTION
支持作业集功能，一键按顺序执行作业集的所有作业（支持突袭）（支持自动编队和信赖干员）

本地构建测试正常
<img width="1440" height="898" alt="image" src="https://github.com/user-attachments/assets/a64225de-5217-4e5d-b1ce-d0f512d04a06" />
<img width="894" height="457" alt="image" src="https://github.com/user-attachments/assets/666ee91f-0641-4ccc-93ee-4cc13e1a61bd" />

## Summary by Sourcery

添加对下载和运行带有共享配置选项的 Copilot 任务集（job sets）的支持，包括自动编队和信赖干员选项。

新功能：
- 引入 Copilot 任务集支持，允许将多个 Copilot 任务作为一个批次按顺序执行。
- 增加用于管理 Copilot 任务集的 UI 和状态，包括列出条目、选择项目以及切换是否使用任务集。
- 支持从远程 API 下载并导入 Copilot 任务集，将其展开为单独的阶段条目，包括突袭（raid）变体。
- 暴露全局 Copilot 选项（自动编队和信赖干员），并将其同时应用于单个和列表 Copilot 配置。

改进：
- 优化 Copilot 删除和选择行为，更好地处理项目移除后的后续选择逻辑。
- 改进 Copilot 及 Copilot 任务集下载与解析过程中的错误日志记录和错误处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for downloading and running copilot job sets with shared configuration options, including automatic formation and trust operators.

New Features:
- Introduce copilot job set support, allowing sequential execution of multiple copilot tasks as a batch.
- Add UI and state to manage copilot job sets, including listing entries, selecting items, and toggling use of job sets.
- Support downloading and importing copilot job sets from remote APIs, expanding them into individual stage entries, including raid variants.
- Expose global copilot options (automatic formation and trust operators) and apply them to both single and list copilot configurations.

Enhancements:
- Refine copilot deletion and selection behavior to better handle removal and subsequent selection of items.
- Improve error logging and handling for copilot and copilot set downloads and parsing.

</details>