### PR TITLE
feat(macOS): 添加复制版本信息功能并显示 Core 版本

### DIFF
--- a/MeoAsstMac/Core/Maa.swift
+++ b/MeoAsstMac/Core/Maa.swift
@@ -10,8 +10,17 @@ import Foundation
 import MaaCore
 import SwiftyJSON
 
+@_silgen_name("AsstGetVersion")
+private func MaaCoreAsstGetVersion() -> UnsafePointer<CChar>
+
 actor MAAProvider {
     static let shared = MAAProvider()
+    
+    static var coreVersion: String {
+        String(cString: MaaCoreAsstGetVersion())
+    }
+
+    
     private init() {}
 
     func loadResource(path: String) throws {

--- a/MeoAsstMac/Core/Maa.swift
+++ b/MeoAsstMac/Core/Maa.swift
@@ -11,15 +11,18 @@ import MaaCore
 import SwiftyJSON
 
 @_silgen_name("AsstGetVersion")
-private func MaaCoreAsstGetVersion() -> UnsafePointer<CChar>
+private func MaaCoreAsstGetVersion() -> UnsafePointer<CChar>?
 
 actor MAAProvider {
     static let shared = MAAProvider()
     
-    static var coreVersion: String {
-        String(cString: MaaCoreAsstGetVersion())
-    }
+    static let coreVersion: String = {
+        guard let versionPointer = MaaCoreAsstGetVersion() else {
+            return "Unknown"
+        }
 
+        return String(cString: versionPointer)
+    }()
     
     private init() {}
 

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -347,6 +347,7 @@ extension MAAViewModel {
             logTrace(
                 """
                 内置资源版本：\(currentResourceVersion.title)
+                MaaCore 版本：\(MAAProvider.coreVersion)
                 更新时间：\(currentResourceVersion.last_updated)
                 """)
             let url = documentsDirectory.appendingPathComponent("resource", isDirectory: true)

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -342,13 +342,14 @@ extension MAAViewModel {
                 """
                 外部资源版本：\(currentResourceVersion.title)
                 更新时间：\(currentResourceVersion.last_updated)
+                \(MaaVersionInfo.coreVersionLogLine())
                 """)
         } else {
             logTrace(
                 """
                 内置资源版本：\(currentResourceVersion.title)
-                MaaCore 版本：\(MAAProvider.coreVersion)
                 更新时间：\(currentResourceVersion.last_updated)
+                \(MaaVersionInfo.coreVersionLogLine())
                 """)
             let url = documentsDirectory.appendingPathComponent("resource", isDirectory: true)
             try? FileManager.default.removeItem(at: url)

--- a/MeoAsstMac/Settings/UpdaterSettingsView.swift
+++ b/MeoAsstMac/Settings/UpdaterSettingsView.swift
@@ -7,6 +7,7 @@
 
 import Sparkle
 import SwiftUI
+import AppKit
 
 struct UpdaterSettingsView: View {
     private let updater: SPUUpdater
@@ -38,6 +39,10 @@ struct UpdaterSettingsView: View {
                 .onChange(of: automaticallyDownloadsUpdates) { newValue in
                     updater.automaticallyDownloadsUpdates = newValue
                 }
+            
+            Button("复制版本信息") {
+                copyVersionInfo()
+            }
 
             Divider()
 
@@ -61,6 +66,15 @@ struct UpdaterSettingsView: View {
         }
         .animation(.default, value: resourceChannel)
         .padding()
+    }
+    
+//复制更详细的版本信息
+    private func copyVersionInfo() {
+        guard let (_, resourceVersion) = try? resourceChannel.version() else { return }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(MaaVersionInfo.text(resourceVersion: resourceVersion), forType: .string)
     }
 }
 

--- a/MeoAsstMac/Utils/ResourceUpdater.swift
+++ b/MeoAsstMac/Utils/ResourceUpdater.swift
@@ -126,4 +126,8 @@ enum MaaVersionInfo {
         Resource Time: \(resourceVersion.last_updated)
         """
     }
+    
+    static func coreVersionLogLine() -> String {
+        String(localized: "Core Version: \(coreVersion)")
+    }
 }

--- a/MeoAsstMac/Utils/ResourceUpdater.swift
+++ b/MeoAsstMac/Utils/ResourceUpdater.swift
@@ -107,3 +107,23 @@ extension MAAResourceChannel {
         return try decoder.decode(MAAResourceVersion.self, from: data)
     }
 }
+
+enum MaaVersionInfo {
+    static var uiVersion: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        return version.hasPrefix("v") ? version : "v\(version)"
+    }
+
+    static var coreVersion: String {
+        MAAProvider.coreVersion
+    }
+
+    static func text(resourceVersion: MAAResourceVersion) -> String {
+        """
+        UI Version: \(uiVersion)
+        Core Version: \(coreVersion)
+        Resource Version: \(resourceVersion.title)
+        Resource Time: \(resourceVersion.last_updated)
+        """
+    }
+}

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1226,6 +1226,15 @@
     "PV-烟花筹委会" : {
 
     },
+    "RA-1" : {
+
+    },
+    "RA-4" : {
+
+    },
+    "RA-15" : {
+
+    },
     "Read item_index.json failed: %@" : {
       "localizations" : {
         "ko" : {
@@ -2238,7 +2247,18 @@
         }
       }
     },
+    "内置资源版本：%@\nMaaCore 版本：%@\n更新时间：%@" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "内置资源版本：%1$@\nMaaCore 版本：%2$@\n更新时间：%3$@"
+          }
+        }
+      }
+    },
     "内置资源版本：%@\n更新时间：%@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ko" : {
           "stringUnit" : {
@@ -2759,6 +2779,9 @@
           }
         }
       }
+    },
+    "复制版本信息" : {
+
     },
     "复制结果JSON至剪贴板：" : {
       "localizations" : {


### PR DESCRIPTION
## 变更内容

- 在 macOS 设置页新增“复制版本信息”功能，方便用户反馈 issue 时复制环境信息
- 复制内容包含：
  - UI Version
  - Core Version
  - Resource Version
  - Resource Time
- 在 GUI 资源版本日志中显示 Core 版本，方便从界面日志中确认当前 Core 构建版本
- 暂不包含 Build Time，避免扩大改动范围

## 实现说明

- UI Version 读取自 App Bundle 的 `CFBundleShortVersionString`
- Core Version 通过 Core 侧 `AsstGetVersion()` 获取
- Resource Version / Resource Time 复用现有 `resourceChannel.version()` 结果
- macOS 侧通过 `@_silgen_name("AsstGetVersion")` 绑定 Core 符号
- 未修改公共 Core 头文件，也未修改构建产物

## 本地测试

Debug 构建下复制版本信息结果示例：

    UI Version: v1.0
    Core Version: DEBUG_VERSION
    Resource Version: 承诺
    Resource Time: 2026-05-22 11:36:07.000

GUI 资源版本日志示例：

    内置资源版本：承诺
    更新时间：2026-05-22 11:36:07.000
    Core 版本：DEBUG_VERSION

Debug 构建下 UI Version 来自 `Version.xcconfig` 中的 `MARKETING_VERSION = 1.0`，Core Version 来自 Debug Core 的 `MAA_VERSION`，因此显示为 `v1.0` 和 `DEBUG_VERSION`。

## 展示视频

https://github.com/user-attachments/assets/59803c45-5b19-4d3b-a607-17592c04df9e

## 由 Sourcery 提供的摘要

为 macOS UI 添加复制详细版本信息的支持，并在应用中暴露 Core 版本数据。

新功能：
- 在 macOS 设置中添加一个按钮，将 UI、Core 和资源的版本信息复制到剪贴板。

增强内容：
- 将 Maa core 库中的 Core 版本信息暴露给 macOS 应用，并将其包含到资源版本日志中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add macOS UI support for copying detailed version information and expose Core version data in the app.

New Features:
- Add a macOS settings button to copy UI, Core, and resource version information to the clipboard.

Enhancements:
- Expose Core version from the Maa core library to the macOS app and include it in resource version logs.

</details>