### PR TITLE
fix: 统一 gui.log 文件日志中的日期与时间格式

### DIFF
--- a/MeoAsstMac/Model/MAALog.swift
+++ b/MeoAsstMac/Model/MAALog.swift
@@ -24,6 +24,24 @@ struct MAALog: Identifiable, Hashable {
     let color: LogColor
 }
 
+extension Date {
+    private func maaLogFormatted(dateFormat: String) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone.current
+        formatter.dateFormat = dateFormat
+        return formatter.string(from: self)
+    }
+
+    var maaGuiLogFormat: String {
+        maaLogFormatted(dateFormat: "MM-dd HH:mm:ss")
+    }
+
+    var maaFileLogFormat: String {
+        maaLogFormatted(dateFormat: "yyyy-MM-dd HH:mm:ss")
+    }
+}
+
 extension MAALog.LogColor {
     var textColor: Color {
         switch self {
@@ -38,27 +56,5 @@ extension MAALog.LogColor {
         case .error:
             return .red
         }
-    }
-}
-
-extension Date {
-    private static let guiLogDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MM-dd HH:mm:ss"
-        return formatter
-    }()
-
-    private static let fileLogDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return formatter
-    }()
-
-    var maaGuiLogFormat: String {
-        Self.guiLogDateFormatter.string(from: self)
-    }
-
-    var maaFileLogFormat: String {
-        Self.fileLogDateFormatter.string(from: self)
     }
 }

--- a/MeoAsstMac/Model/MAALog.swift
+++ b/MeoAsstMac/Model/MAALog.swift
@@ -5,6 +5,7 @@
 //  Created by hguandl on 16/4/2023.
 //
 
+import Foundation
 import SwiftUI
 
 struct MAALog: Identifiable, Hashable {
@@ -37,5 +38,27 @@ extension MAALog.LogColor {
         case .error:
             return .red
         }
+    }
+}
+
+extension Date {
+    private static let guiLogDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM-dd HH:mm:ss"
+        return formatter
+    }()
+
+    private static let fileLogDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter
+    }()
+
+    var maaGuiLogFormat: String {
+        Self.guiLogDateFormatter.string(from: self)
+    }
+
+    var maaFileLogFormat: String {
+        Self.fileLogDateFormatter.string(from: self)
     }
 }

--- a/MeoAsstMac/Utils/FileLogger.swift
+++ b/MeoAsstMac/Utils/FileLogger.swift
@@ -28,7 +28,7 @@ struct FileLogger: ~Copyable {
     }
 
     func write(_ log: MAALog) {
-        let line = "[\(log.date)][\(log.color)]\(log.content.replacingOccurrences(of: "\n", with: " "))\n"
+        let line = "[\(log.date.maaFileLogFormat)][\(log.color)]\(log.content.replacingOccurrences(of: "\n", with: " "))\n"
         if let data = line.data(using: .utf8) {
             fileHandle?.write(data)
         }

--- a/MeoAsstMac/Views/LogView.swift
+++ b/MeoAsstMac/Views/LogView.swift
@@ -13,7 +13,7 @@ struct LogView: View {
     var body: some View {
         ScrollViewReader { proxy in
             Table(viewModel.logs) {
-                TableColumn("时间", value: \.date.maaFormat)
+                TableColumn("时间", value: \.date.maaGuiLogFormat)
                     .width(min: 100, ideal: 125, max: 150)
                 TableColumn("信息") { log in
                     Text(log.content)
@@ -49,14 +49,6 @@ struct LogView: View {
                 }
             }
         }
-    }
-}
-
-extension Date {
-    fileprivate var maaFormat: String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "MM-dd HH:mm:ss"
-        return dateFormatter.string(from: self)
     }
 }
 


### PR DESCRIPTION
Try fix https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/17023.

## Summary by Sourcery

统一 GUI 和文件日志的日期时间格式，并将日志日期格式化逻辑集中管理。

Enhancements:
- 引入共享的 `Date` 扩展，为 GUI 日志显示和文件日志条目提供标准化格式。
- 更新日志表以使用新的 GUI 日志日期格式辅助方法。
- 修改文件记录器以使用新的文件日志日期格式辅助方法来格式化时间戳。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify date and time formatting for GUI and file logs and centralize the log date formatting logic.

Enhancements:
- Introduce shared Date extension providing standardized formats for GUI log display and file log entries.
- Update log table to use the new GUI log date format helper.
- Change file logger to format timestamps using the new file log date format helper.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一 GUI 和文件日志的日期时间格式，并将日志日期格式化逻辑集中管理。

Enhancements:
- 引入共享的 `Date` 扩展，为 GUI 日志显示和文件日志条目提供标准化格式。
- 更新日志表以使用新的 GUI 日志日期格式辅助方法。
- 修改文件记录器以使用新的文件日志日期格式辅助方法来格式化时间戳。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify date and time formatting for GUI and file logs and centralize the log date formatting logic.

Enhancements:
- Introduce shared Date extension providing standardized formats for GUI log display and file log entries.
- Update log table to use the new GUI log date format helper.
- Change file logger to format timestamps using the new file log date format helper.

</details>

</details>