### PR TITLE
feat: 同步 WPF 版周计划功能，为刷理智任务添加每周执行日设置

### DIFF
--- a/MeoAsstMac/Configuration Views/FightSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/FightSettingsView.swift
@@ -105,9 +105,26 @@ struct FightSettingsView: View {
             TextField(text: $config.penguin_id) {
                 Toggle("企鹅物流汇报ID", isOn: $config.report_to_penguin)
             }
+
+            Divider()
+
+            Section {
+                Toggle(String(localized: "启用周计划"), isOn: $config.useWeeklySchedule)
+                if config.useWeeklySchedule {
+                    Text((String(localized: "此处星期根据游戏时间计算（每日 4:00 刷新），而非现实时间。例如游戏在 4:00 刷新，则 3:59 仍算作前一天。")))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]) {
+                        ForEach(weekdayRange, id: \.self) { day in
+                            Toggle(weekdayLabel(for: day), isOn: weekdayBinding(for: day))
+                        }
+                    }
+                }
+            }
         }
         .padding()
         .animation(.default, value: useCustomStage)
+        .animation(.default, value: config.useWeeklySchedule)
     }
 
     private var useExpiringMedicine: Binding<Bool> {
@@ -212,6 +229,23 @@ struct FightSettingsView: View {
 
     private var stageNotListed: Bool { !listedStages.contains(config.stage) }
     private let listedStages = ["", "1-7", "CE-6", "AP-5", "CA-5", "LS-6", "Annihilation"]
+
+    // MARK: - Weekly Schedule
+
+    private let weekdayRange = 1...7
+    private let weekdaySymbols = Calendar.current.shortWeekdaySymbols
+
+    private func weekdayLabel(for day: Int) -> String {
+        weekdaySymbols[day - 1]
+    }
+
+    private func weekdayBinding(for day: Int) -> Binding<Bool> {
+        Binding {
+            config.weeklySchedule[day]
+        } set: {
+            config.weeklySchedule[day] = $0
+        }
+    }
 }
 
 struct FightSettingsView_Previews: PreviewProvider {

--- a/MeoAsstMac/Configuration Views/FightSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/FightSettingsView.swift
@@ -109,9 +109,26 @@ struct FightSettingsView: View {
             TextField(text: $config.penguin_id) {
                 Toggle("企鹅物流汇报ID", isOn: $config.report_to_penguin)
             }
+
+            Divider()
+
+            Section {
+                Toggle(String(localized: "启用周计划"), isOn: $config.useWeeklySchedule)
+                if config.useWeeklySchedule {
+                    Text((String(localized: "此处星期根据游戏时间计算（每日 4:00 刷新），而非现实时间。例如游戏在 4:00 刷新，则 3:59 仍算作前一天。")))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]) {
+                        ForEach(weekdayRange, id: \.self) { day in
+                            Toggle(weekdayLabel(for: day), isOn: weekdayBinding(for: day))
+                        }
+                    }
+                }
+            }
         }
         .padding()
         .animation(.default, value: useCustomStage)
+        .animation(.default, value: config.useWeeklySchedule)
     }
 
     private var useMedicine: Binding<Bool> {
@@ -208,6 +225,23 @@ struct FightSettingsView: View {
 
     private var stageNotListed: Bool { !listedStages.contains(config.stage) }
     private let listedStages = ["", "1-7", "CE-6", "AP-5", "CA-5", "LS-6", "Annihilation"]
+
+    // MARK: - Weekly Schedule
+
+    private let weekdayRange = 1...7
+    private let weekdaySymbols = Calendar.current.shortWeekdaySymbols
+
+    private func weekdayLabel(for day: Int) -> String {
+        weekdaySymbols[day - 1]
+    }
+
+    private func weekdayBinding(for day: Int) -> Binding<Bool> {
+        Binding {
+            config.weeklySchedule[day]
+        } set: {
+            config.weeklySchedule[day] = $0
+        }
+    }
 }
 
 struct FightSettingsView_Previews: PreviewProvider {

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -464,8 +464,18 @@ extension MAAViewModel {
 
         try await ensureHandle()
 
+        let today = Self.inGameDayOfWeek(for: clientChannel)
+
         for task in tasks {
             guard task.enabled else { continue }
+
+            if case .fight(let config) = task.task,
+               config.useWeeklySchedule,
+               !config.weeklySchedule.isEnabled(for: today)
+            {
+                logInfo("跳过刷理智任务（今日不在周计划内）")
+                continue
+            }
 
             if let coreID = try await handle?.appendTask(task.task) {
                 taskIDMap[coreID] = task.id
@@ -708,5 +718,25 @@ extension MAAViewModel {
     func stopGame() async throws {
         guard let client = await MaaToolClient(address: connectionAddress) else { return }
         try await client.terminate()
+    }
+}
+
+extension MAAViewModel {
+    private static let serverUTCOffsets: [MAAClientChannel: Int] = [
+        .Official: 8,
+        .Bilibili: 8,
+        .txwy: 8,
+        .YoStarEN: -7,
+        .YoStarJP: 9,
+        .YoStarKR: 9,
+    ]
+
+    static func inGameDayOfWeek(for channel: MAAClientChannel) -> Int {
+        let offset = serverUTCOffsets[channel] ?? 8
+        let yjShift = (offset - 4) * 3600
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let adjusted = Date().addingTimeInterval(TimeInterval(yjShift))
+        return calendar.component(.weekday, from: adjusted)
     }
 }

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -468,8 +468,18 @@ extension MAAViewModel {
 
         try await ensureHandle()
 
+        let today = Self.inGameDayOfWeek(for: clientChannel)
+
         for task in tasks {
             guard task.enabled else { continue }
+
+            if case .fight(let config) = task.task,
+               config.useWeeklySchedule,
+               !config.weeklySchedule.isEnabled(for: today)
+            {
+                logInfo("跳过刷理智任务（今日不在周计划内）")
+                continue
+            }
 
             if let coreID = try await handle?.appendTask(task.task) {
                 taskIDMap[coreID] = task.id
@@ -708,5 +718,25 @@ extension MAAViewModel {
     func stopGame() async throws {
         guard let client = await MaaToolClient(address: connectionAddress) else { return }
         try await client.terminate()
+    }
+}
+
+extension MAAViewModel {
+    private static let serverUTCOffsets: [MAAClientChannel: Int] = [
+        .Official: 8,
+        .Bilibili: 8,
+        .txwy: 8,
+        .YoStarEN: -7,
+        .YoStarJP: 9,
+        .YoStarKR: 9,
+    ]
+
+    static func inGameDayOfWeek(for channel: MAAClientChannel) -> Int {
+        let offset = serverUTCOffsets[channel] ?? 8
+        let yjShift = (offset - 4) * 3600
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let adjusted = Date().addingTimeInterval(TimeInterval(yjShift))
+        return calendar.component(.weekday, from: adjusted)
     }
 }

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -477,7 +477,7 @@ extension MAAViewModel {
                config.useWeeklySchedule,
                !config.weeklySchedule.isEnabled(for: today)
             {
-                logInfo("跳过刷理智任务（今日不在周计划内）")
+                logInfo(.weeklyScheduleSkippedFight)
                 continue
             }
 

--- a/MeoAsstMac/Task Configurations/FightConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/FightConfiguration.swift
@@ -7,6 +7,45 @@
 
 import Foundation
 
+struct WeeklySchedule: Codable, Equatable, Hashable {
+    var sunday: Bool = true
+    var monday: Bool = true
+    var tuesday: Bool = true
+    var wednesday: Bool = true
+    var thursday: Bool = true
+    var friday: Bool = true
+    var saturday: Bool = true
+
+    func isEnabled(for weekday: Int) -> Bool {
+        switch weekday {
+        case 1: return sunday
+        case 2: return monday
+        case 3: return tuesday
+        case 4: return wednesday
+        case 5: return thursday
+        case 6: return friday
+        case 7: return saturday
+        default: return true
+        }
+    }
+
+    subscript(_ index: Int) -> Bool {
+        get { isEnabled(for: index) }
+        set {
+            switch index {
+            case 1: sunday = newValue
+            case 2: monday = newValue
+            case 3: tuesday = newValue
+            case 4: wednesday = newValue
+            case 5: thursday = newValue
+            case 6: friday = newValue
+            case 7: saturday = newValue
+            default: break
+            }
+        }
+    }
+}
+
 struct FightConfiguration: MAATaskConfiguration {
     var type: MAATaskType { .Fight }
 
@@ -23,6 +62,9 @@ struct FightConfiguration: MAATaskConfiguration {
     var server: String
     var client_type: String
     var DrGrandet: Bool
+
+    var useWeeklySchedule: Bool
+    var weeklySchedule: WeeklySchedule
 
     var title: String {
         type.description
@@ -141,5 +183,7 @@ extension FightConfiguration {
         self.server = try container.decodeIfPresent(String.self, forKey: .server) ?? "CN"
         self.client_type = try container.decodeIfPresent(String.self, forKey: .client_type) ?? ""
         self.DrGrandet = try container.decodeIfPresent(Bool.self, forKey: .DrGrandet) ?? false
+        self.useWeeklySchedule = try container.decodeIfPresent(Bool.self, forKey: .useWeeklySchedule) ?? false
+        self.weeklySchedule = try container.decodeIfPresent(WeeklySchedule.self, forKey: .weeklySchedule) ?? WeeklySchedule()
     }
 }

--- a/MeoAsstMac/Task Configurations/FightConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/FightConfiguration.swift
@@ -7,6 +7,45 @@
 
 import Foundation
 
+struct WeeklySchedule: Codable, Equatable, Hashable {
+    var sunday: Bool = true
+    var monday: Bool = true
+    var tuesday: Bool = true
+    var wednesday: Bool = true
+    var thursday: Bool = true
+    var friday: Bool = true
+    var saturday: Bool = true
+
+    func isEnabled(for weekday: Int) -> Bool {
+        switch weekday {
+        case 1: return sunday
+        case 2: return monday
+        case 3: return tuesday
+        case 4: return wednesday
+        case 5: return thursday
+        case 6: return friday
+        case 7: return saturday
+        default: return true
+        }
+    }
+
+    subscript(_ index: Int) -> Bool {
+        get { isEnabled(for: index) }
+        set {
+            switch index {
+            case 1: sunday = newValue
+            case 2: monday = newValue
+            case 3: tuesday = newValue
+            case 4: wednesday = newValue
+            case 5: thursday = newValue
+            case 6: friday = newValue
+            case 7: saturday = newValue
+            default: break
+            }
+        }
+    }
+}
+
 struct FightConfiguration: MAATaskConfiguration {
     var type: MAATaskType { .Fight }
 
@@ -23,6 +62,9 @@ struct FightConfiguration: MAATaskConfiguration {
     var server: String
     var client_type: String
     var DrGrandet: Bool
+
+    var useWeeklySchedule: Bool
+    var weeklySchedule: WeeklySchedule
 
     var title: String {
         type.description
@@ -151,6 +193,8 @@ extension FightConfiguration {
         self.server = try container.decodeIfPresent(String.self, forKey: .server) ?? "CN"
         self.client_type = try container.decodeIfPresent(String.self, forKey: .client_type) ?? ""
         self.DrGrandet = try container.decodeIfPresent(Bool.self, forKey: .DrGrandet) ?? false
+        self.useWeeklySchedule = try container.decodeIfPresent(Bool.self, forKey: .useWeeklySchedule) ?? false
+        self.weeklySchedule = try container.decodeIfPresent(WeeklySchedule.self, forKey: .weeklySchedule) ?? WeeklySchedule()
     }
 }
 

--- a/MeoAsstMac/Task Configurations/LegacyConfigurations.swift
+++ b/MeoAsstMac/Task Configurations/LegacyConfigurations.swift
@@ -100,6 +100,8 @@ extension FightConfiguration {
         self.server = config.server
         self.client_type = config.client_type
         self.DrGrandet = config.DrGrandet
+        self.useWeeklySchedule = false
+        self.weeklySchedule = WeeklySchedule()
     }
 }
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2681,6 +2681,34 @@
         }
       }
     },
+    "启用周计划" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Weekly Schedule"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "週間スケジュールを有効にする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주간 일정 활성화"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用週計劃"
+          }
+        }
+      }
+    },
     "周常任务" : {
       "localizations" : {
         "ko" : {
@@ -3689,6 +3717,34 @@
         }
       }
     },
+    "此处星期根据游戏时间计算（每日 4:00 刷新），而非现实时间。例如游戏在 4:00 刷新，则 3:59 仍算作前一天。" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The day of week here is based on in-game time (daily reset at 4:00), not real time. For example, if the game resets at 4:00, 3:59 is still counted as the previous day."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ここでの曜日はゲーム内時間（毎日4:00リセット）に基づいて計算され、実際の時間ではありません。例えば、ゲームが4:00にリセットされる場合、3:59はまだ前日としてカウントされます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여기서 요일은 게임 내 시간(매일 4:00 초기화)을 기준으로 계산되며 실제 시간이 아닙니다. 예를 들어 게임이 4:00에 초기화되면 3:59는 여전히 전날로 계산됩니다."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此處星期根據遊戲時間計算（每日 4:00 刷新），而非現實時間。例如遊戲在 4:00 刷新，則 3:59 仍算作前一天。"
+          }
+        }
+      }
+    },
     "每次执行时最大招募次数: " : {
       "localizations" : {
         "ko" : {
@@ -4624,6 +4680,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "리소스 업데이트 출처"
+          }
+        }
+      }
+    },
+    "跳过刷理智任务（今日不在周计划内）" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skipped fight task (not in today's weekly schedule)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "戦闘任務をスキップしました（本日の週間スケジュールに含まれていません）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전투 작업을 건너뜁니다 (오늘의 주간 일정에 없음)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳過刷理智任務（今日不在週計劃內）"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -3883,6 +3883,34 @@
     "启用滑动绘制" : {
 
     },
+    "启用周计划" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Weekly Schedule"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "週間スケジュールを有効にする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주간 일정 활성화"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用週計劃"
+          }
+        }
+      }
+    },
     "周常任务" : {
       "localizations" : {
         "ko" : {
@@ -4914,6 +4942,34 @@
         }
       }
     },
+    "此处星期根据游戏时间计算（每日 4:00 刷新），而非现实时间。例如游戏在 4:00 刷新，则 3:59 仍算作前一天。" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The day of week here is based on in-game time (daily reset at 4:00), not real time. For example, if the game resets at 4:00, 3:59 is still counted as the previous day."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ここでの曜日はゲーム内時間（毎日4:00リセット）に基づいて計算され、実際の時間ではありません。例えば、ゲームが4:00にリセットされる場合、3:59はまだ前日としてカウントされます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여기서 요일은 게임 내 시간(매일 4:00 초기화)을 기준으로 계산되며 실제 시간이 아닙니다. 예를 들어 게임이 4:00에 초기화되면 3:59는 여전히 전날로 계산됩니다."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此處星期根據遊戲時間計算（每日 4:00 刷新），而非現實時間。例如遊戲在 4:00 刷新，則 3:59 仍算作前一天。"
+          }
+        }
+      }
+    },
     "每次执行时最大招募次数: " : {
       "localizations" : {
         "ko" : {
@@ -5909,6 +5965,37 @@
           }
         }
       }
+    },
+    "跳过刷理智任务（今日不在周计划内）" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skipped fight task (not in today's weekly schedule)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "戦闘任務をスキップしました（本日の週間スケジュールに含まれていません）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전투 작업을 건너뜁니다 (오늘의 주간 일정에 없음)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳過刷理智任務（今日不在週計劃內）"
+          }
+        }
+      }
+    },
+    "过完新手教程后进入前哨支点，滑动到界面最左侧。" : {
+
     },
     "运行日志" : {
       "localizations" : {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2950,6 +2950,41 @@
         }
       }
     },
+    "WeeklyScheduleSkippedFight" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skipped fight task (not in today's weekly schedule)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "戦闘任務をスキップしました（本日の週間スケジュールに含まれていません）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전투 작업을 건너뜁니다 (오늘의 주간 일정에 없음)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳过刷理智任务（今日不在周计划内）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳過刷理智任務（今日不在週計劃內）"
+          }
+        }
+      }
+    },
     "一层远见密文板" : {
       "localizations" : {
         "ko" : {
@@ -5962,34 +5997,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "리소스 업데이트 출처"
-          }
-        }
-      }
-    },
-    "跳过刷理智任务（今日不在周计划内）" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skipped fight task (not in today's weekly schedule)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "戦闘任務をスキップしました（本日の週間スケジュールに含まれていません）"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전투 작업을 건너뜁니다 (오늘의 주간 일정에 없음)"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跳過刷理智任務（今日不在週計劃內）"
           }
         }
       }


### PR DESCRIPTION
在 mac 版 GUI 的刷理智任务设置中新增周计划选项，与 WPF 版本行为一致。

## 修改内容

- 启用周计划后可在设置中勾选每周哪几天执行该任务
- 非启用日自动跳过并记录日志，不会发送给 MaaCore
- 星期按游戏时间计算（每日 4:00 刷新），根据设置中的游戏区服自动适配时区。

## 涉及文件

- `FightConfiguration.swift` — 新增 WeeklySchedule 结构体及 useWeeklySchedule / weeklySchedule 属性
- `FightSettingsView.swift` — 新增周计划设置区域（开关 + 7 天勾选 + 提示文字）
- `MAAViewModel.swift` — 新增 inGameDayOfWeek 游戏星期计算及 startTasks() 跳过逻辑
- `LegacyConfigurations.swift` — 旧配置迁移路径初始化新字段
- `Localizable.xcstrings` — 新增中/英/日/韩/繁翻译

## 截图

### 1. 设置界面未勾选周计划选项

<img width="1044" height="753" alt="截屏2026-06-07 22 35 32" src="https://github.com/user-attachments/assets/ada864ca-2c23-4c7e-b114-9c7ebc81889c" />

### 2. 设置界面勾选周计划选项

<img width="1044" height="753" alt="截屏2026-06-07 22 28 08" src="https://github.com/user-attachments/assets/1daeab75-d0bd-475b-9203-368451989866" />

### 3. 日志界面

<img width="1044" height="753" alt="截屏2026-06-07 22 28 56" src="https://github.com/user-attachments/assets/7530e59b-3625-4d4c-8366-7ae90ffeb97e" />

## 测试

* 本地构建并启动 macOS GUI。
* 添加多个刷理智任务并设置执行日。
* 确认仅当日对应刷理智任务运行。

## Sourcery 摘要

根据每个服务器的游戏内日期，为战斗任务添加可配置的每周执行计划。

新功能：
- 为战斗任务添加可选的每周计划，允许用户选择每个任务运行的日期。
- 使用游戏内时间和配置的服务器区域计算计划日期。

错误修复：
- 在禁用日期的战斗任务提交到 MaaCore 之前跳过这些任务，并在日志中记录跳过操作。

改进：
- 通过为现有配置中的每周计划字段提供默认值，保持向后兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable weekly execution schedules for fight tasks based on each server’s in-game day.

New Features:
- Add optional weekly scheduling for fight tasks, allowing users to select the days on which each task runs.
- Calculate scheduled days using in-game time and the configured server region.

Bug Fixes:
- Skip disabled-day fight tasks before they are submitted to MaaCore and record the skip in logs.

Enhancements:
- Preserve backward compatibility by supplying defaults for weekly scheduling fields in existing configurations.

</details>

<details>
<summary>Original summary in English</summary>



</details>