### PR TITLE
feat(fight): 支持关卡开放状态及今日提示

### DIFF
--- a/MeoAsstMac.xcodeproj/project.pbxproj
+++ b/MeoAsstMac.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F10000000000000000000002 /* StageCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000000000000000000001 /* StageCatalog.swift */; };
+		F10000000000000000000003 /* StageCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000000000000000000001 /* StageCatalog.swift */; };
+		F10000000000000000000005 /* StageCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000000000000000000004 /* StageCatalogTests.swift */; };
+		F20000000000000000000002 /* TodayStageTipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20000000000000000000001 /* TodayStageTipView.swift */; };
 		830C3D1C29BC7D8600B13A9F /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 830C3D1B29BC7D8600B13A9F /* Sparkle */; };
 		830C3D1E29BC7DE200B13A9F /* CheckForUpdatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830C3D1D29BC7DE200B13A9F /* CheckForUpdatesView.swift */; };
 		8315B0BD290E48F300AE7FDC /* StartupSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8315B0BC290E48F300AE7FDC /* StartupSettingsView.swift */; };
@@ -131,6 +135,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		F10000000000000000000001 /* StageCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageCatalog.swift; sourceTree = "<group>"; };
+		F10000000000000000000004 /* StageCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageCatalogTests.swift; sourceTree = "<group>"; };
+		F10000000000000000000006 /* MeoAsstMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MeoAsstMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F20000000000000000000001 /* TodayStageTipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayStageTipView.swift; sourceTree = "<group>"; };
 		830C3D1D29BC7DE200B13A9F /* CheckForUpdatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckForUpdatesView.swift; sourceTree = "<group>"; };
 		830C3D1F29BC86EE00B13A9F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8315B0BC290E48F300AE7FDC /* StartupSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupSettingsView.swift; sourceTree = "<group>"; };
@@ -225,6 +233,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		F10000000000000000000009 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		833786C828F188D800D39D6F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -337,6 +352,7 @@
 				832985B829EF9D50009F7ED5 /* MAAContent.swift */,
 				832985BC29EFA43B009F7ED5 /* MAADetail.swift */,
 				8355E7B329E918A2005D5A1C /* TasksContent.swift */,
+				F20000000000000000000001 /* TodayStageTipView.swift */,
 				8341195C29EC719B00044F45 /* CopilotContent.swift */,
 				832985AD29EEE672009F7ED5 /* UtilityContent.swift */,
 				832985BA29EFA26D009F7ED5 /* TaskDetail.swift */,
@@ -355,6 +371,7 @@
 				8368855029BD851F00C5B999 /* Version.xcconfig */,
 				83885C112C4D5D1500B02663 /* README.md */,
 				83782A292CFFA43200A32BDD /* Packages */,
+				F10000000000000000000007 /* MeoAsstMacTests */,
 				833786CC28F188D800D39D6F /* Products */,
 				83245A0128F467C300ED6D4C /* Frameworks */,
 			);
@@ -364,6 +381,7 @@
 			isa = PBXGroup;
 			children = (
 				833786CB28F188D800D39D6F /* MAA.app */,
+				F10000000000000000000006 /* MeoAsstMacTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -431,6 +449,7 @@
 				832985B329EF1219009F7ED5 /* MAARecruit.swift */,
 				83CFD47029EAACD7000428A1 /* MAATask.swift */,
 				83264A3D29EC22DE0074E33A /* MAAViewModel.swift */,
+				F10000000000000000000001 /* StageCatalog.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -479,9 +498,34 @@
 			path = Utils;
 			sourceTree = "<group>";
 		};
+		F10000000000000000000007 /* MeoAsstMacTests */ = {
+			isa = PBXGroup;
+			children = (
+				F10000000000000000000004 /* StageCatalogTests.swift */,
+			);
+			path = MeoAsstMacTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		F1000000000000000000000B /* MeoAsstMacTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F1000000000000000000000E /* Build configuration list for PBXNativeTarget "MeoAsstMacTests" */;
+			buildPhases = (
+				F10000000000000000000008 /* Sources */,
+				F10000000000000000000009 /* Frameworks */,
+				F1000000000000000000000A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MeoAsstMacTests;
+			productName = MeoAsstMacTests;
+			productReference = F10000000000000000000006 /* MeoAsstMacTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		833786CA28F188D800D39D6F /* MAA */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 833786DA28F188D900D39D6F /* Build configuration list for PBXNativeTarget "MAA" */;
@@ -520,6 +564,9 @@
 					833786CA28F188D800D39D6F = {
 						CreatedOnToolsVersion = 14.0.1;
 					};
+					F1000000000000000000000B = {
+						CreatedOnToolsVersion = 26.0;
+					};
 				};
 			};
 			buildConfigurationList = 833786C628F188D800D39D6F /* Build configuration list for PBXProject "MeoAsstMac" */;
@@ -542,11 +589,19 @@
 			projectRoot = "";
 			targets = (
 				833786CA28F188D800D39D6F /* MAA */,
+				F1000000000000000000000B /* MeoAsstMacTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		F1000000000000000000000A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		833786C928F188D800D39D6F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -562,12 +617,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		F10000000000000000000008 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F10000000000000000000003 /* StageCatalog.swift in Sources */,
+				F10000000000000000000005 /* StageCatalogTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		833786C728F188D800D39D6F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F10000000000000000000002 /* StageCatalog.swift in Sources */,
 				8341195D29EC719B00044F45 /* CopilotContent.swift in Sources */,
 				8355E7B429E918A2005D5A1C /* TasksContent.swift in Sources */,
+				F20000000000000000000002 /* TodayStageTipView.swift in Sources */,
 				832985AA29EE9958009F7ED5 /* RecruitView.swift in Sources */,
 				83264A3B29EC0F2E0074E33A /* LogView.swift in Sources */,
 				83812ED22D5B0B8100CB39D6 /* Binding+semicolonString.swift in Sources */,
@@ -644,6 +710,32 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		F1000000000000000000000C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hguandl.MeoAsstMacTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F1000000000000000000000D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hguandl.MeoAsstMacTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		833786D828F188D900D39D6F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8368855029BD851F00C5B999 /* Version.xcconfig */;
@@ -830,6 +922,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		F1000000000000000000000E /* Build configuration list for PBXNativeTarget "MeoAsstMacTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F1000000000000000000000C /* Debug */,
+				F1000000000000000000000D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		833786C628F188D800D39D6F /* Build configuration list for PBXProject "MeoAsstMac" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/MeoAsstMac.xcodeproj/xcshareddata/xcschemes/MeoAsstMacTests.xcscheme
+++ b/MeoAsstMac.xcodeproj/xcshareddata/xcschemes/MeoAsstMacTests.xcscheme
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F1000000000000000000000B"
+               BuildableName = "MeoAsstMacTests.xctest"
+               BlueprintName = "MeoAsstMacTests"
+               ReferencedContainer = "container:MeoAsstMac.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F1000000000000000000000B"
+               BuildableName = "MeoAsstMacTests.xctest"
+               BlueprintName = "MeoAsstMacTests"
+               ReferencedContainer = "container:MeoAsstMac.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MeoAsstMac/Configuration Views/FightSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/FightSettingsView.swift
@@ -8,35 +8,17 @@
 import SwiftUI
 
 struct FightSettingsView: View {
+    @EnvironmentObject private var viewModel: MAAViewModel
     @Binding var config: FightConfiguration
 
     @State private var useCustomStage = false
     @State private var dropItemList: [(name: String, id: String)] = []
+    @AppStorage("MAAShowUnavailableStages") private var showUnavailableStages = false
 
     var body: some View {
         Form {
-            Section {
-                HStack(spacing: 20) {
-                    if useCustomStage || stageNotListed {
-                        TextField("关卡名", text: $config.stage)
-                    } else {
-                        Picker("关卡选择", selection: $config.stage) {
-                            Text("当前/上次").tag("")
-                            Text("1-7").tag("1-7")
-                            Text("CE-6").tag("CE-6")
-                            Text("AP-5").tag("AP-5")
-                            Text("CA-5").tag("CA-5")
-                            Text("LS-6").tag("LS-6")
-                            Text("剿灭模式").tag("Annihilation")
-                        }
-                    }
-                    Toggle("手动输入关卡名", isOn: isUsingCustomStage)
-                }
-                .animation(.default, value: config.stage)
-            }
-
-            if useCustomStage || stageNotListed {
-                Text("<无忧梦呓>请使用特殊关卡名，如AveMujica-8").foregroundStyle(.secondary)
+            TimelineView(.periodic(from: .now, by: 60)) { context in
+                stageSettings(now: context.date)
             }
 
             Divider()
@@ -210,12 +192,123 @@ struct FightSettingsView: View {
         }
     }
 
-    private var stageNotListed: Bool { !listedStages.contains(config.stage) }
-    private let listedStages = ["", "1-7", "CE-6", "AP-5", "CA-5", "LS-6", "Annihilation"]
+    @ViewBuilder
+    private func stageSettings(now: Date) -> some View {
+        Section {
+            HStack(spacing: 20) {
+                if useCustomStage || stageNotListed {
+                    TextField("关卡名", text: $config.stage)
+                } else {
+                    Picker("关卡选择", selection: $config.stage) {
+                        stageOptions(now: now)
+                    }
+                }
+                Toggle("手动输入关卡名", isOn: isUsingCustomStage)
+            }
+            .animation(.default, value: config.stage)
+
+            if !useCustomStage && !stageNotListed {
+                Toggle("显示今日未开放关卡", isOn: $showUnavailableStages)
+            }
+        }
+
+        if useCustomStage || stageNotListed {
+            Text("<无忧梦呓>请使用特殊关卡名，如AveMujica-8").foregroundStyle(.secondary)
+        } else if let selected = selectedUnavailableStage(now: now) {
+            switch selected.availability {
+            case .closedForWeeklySchedule:
+                Text("所选关卡 \(selected.stage.id) 今日未开放，执行前将自动重置为当前/上次")
+                    .foregroundStyle(.orange)
+            case .activityNotStarted, .activityExpired:
+                Text("所选活动关卡 \(selected.stage.id) 尚未开始或已经结束，执行前将自动重置为当前/上次")
+                    .foregroundStyle(.orange)
+            case .unsupportedCoreVersion(let required):
+                Text("所选活动关卡需要 MaaCore \(required) 或更高版本")
+                    .foregroundStyle(.orange)
+            case .open:
+                EmptyView()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func stageOptions(now: Date) -> some View {
+        let stages = pickerStages(now: now)
+        let permanent = stages.filter { $0.kind == .permanent }
+        let resources = stages.filter {
+            ($0.kind == .resource || $0.kind == .chip) && availability(of: $0, now: now).isOpen
+        }
+        let sideStories = stages.filter { $0.kind == .sideStory && availability(of: $0, now: now).isOpen }
+        let unavailable = stages.filter { !availability(of: $0, now: now).isOpen }
+
+        Section("常用关卡") {
+            ForEach(permanent) { stage in
+                Text(LocalizedStringKey(stage.display)).tag(stage.id)
+            }
+        }
+        if !resources.isEmpty {
+            Section("今日资源本") {
+                ForEach(resources) { stage in
+                    Text(LocalizedStringKey(stage.display)).tag(stage.id)
+                }
+            }
+        }
+        if !sideStories.isEmpty {
+            Section("活动关卡") {
+                ForEach(sideStories) { stage in
+                    Text(stage.display).tag(stage.id)
+                }
+            }
+        }
+        if !unavailable.isEmpty {
+            Section("今日未开放") {
+                ForEach(unavailable) { stage in
+                    HStack {
+                        Text(LocalizedStringKey(stage.display))
+                        Text("今日未开放").foregroundStyle(.secondary)
+                    }
+                    .tag(stage.id)
+                }
+            }
+        }
+    }
+
+    private var server: StageServer {
+        StageServer(channelRawValue: viewModel.clientChannel.rawValue)
+    }
+
+    private var allStages: [StageDescriptor] {
+        viewModel.stageCatalog.stages(for: server)
+    }
+
+    private func pickerStages(now: Date) -> [StageDescriptor] {
+        allStages.filter { stage in
+            let availability = availability(of: stage, now: now)
+            if availability.isOpen { return true }
+            if stage.id == config.stage { return true }
+            return showUnavailableStages && (stage.kind == .resource || stage.kind == .chip)
+        }
+    }
+
+    private func availability(of stage: StageDescriptor, now: Date) -> StageAvailability {
+        viewModel.stageCatalog.availability(
+            of: stage,
+            server: server,
+            now: now,
+            coreVersion: MAAProvider.version)
+    }
+
+    private func selectedUnavailableStage(now: Date) -> (stage: StageDescriptor, availability: StageAvailability)? {
+        guard let stage = allStages.first(where: { $0.id == config.stage }) else { return nil }
+        let availability = availability(of: stage, now: now)
+        return availability.isOpen ? nil : (stage, availability)
+    }
+
+    private var stageNotListed: Bool { !allStages.contains { $0.id == config.stage } }
 }
 
 struct FightSettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        FightSettingsView(config: .constant(.init()))
+        FightSettingsView(config: .constant(.init())).environmentObject(MAAViewModel())
     }
 }

--- a/MeoAsstMac/Core/Maa.swift
+++ b/MeoAsstMac/Core/Maa.swift
@@ -17,6 +17,10 @@ actor MAAProvider {
     static let shared = MAAProvider()
     private init() {}
 
+    nonisolated static var version: String {
+        String(cString: AsstGetVersion())
+    }
+
     func loadResource(path: String) throws {
         guard AsstLoadResource(path).isTrue else {
             throw MaaCoreError.loadResourceFailed

--- a/MeoAsstMac/Model/MAAError.swift
+++ b/MeoAsstMac/Model/MAAError.swift
@@ -12,4 +12,5 @@ enum MAAError: Error {
     case gameStartFailed
     case handleNotRunning
     case imageUnavailable
+    case fightTaskAppendFailed(String)
 }

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -64,6 +64,7 @@ import SwiftUI
     }
 
     @Published var taskStatus: [UUID: TaskStatus] = [:]
+    @Published private(set) var stageCatalog = StageCatalog()
 
     var tasksDirectory: URL {
         Self.userDirectory.appendingPathComponent("DailyTasks", isDirectory: true)
@@ -280,6 +281,7 @@ extension MAAViewModel {
     func reloadResources(channel: MAAClientChannel) async throws {
         let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         try await loadResource(url: documentsDirectory, channel: channel)
+        reloadStageCatalog(at: documentsDirectory.appendingPathComponent("cache", isDirectory: true))
     }
 
     /// Load base resources and channel-specific resources.
@@ -319,7 +321,7 @@ extension MAAViewModel {
         let otaFetcher = OTAFetcher()
         var files = [
             (path: "resource/tasks.json", name: "resource/tasks/tasks.json"),
-            (path: "gui/StageActivity.json", name: "gui/StageActivity.json"),
+            (path: "gui/StageActivityV2.json", name: "gui/StageActivityV2.json"),
         ]
         if channel.isGlobal {
             files.append(
@@ -363,13 +365,19 @@ extension MAAViewModel {
             try? FileManager.default.removeItem(at: url)
         }
 
+        let cachedBaseURL = documentsDirectory.appendingPathComponent("cache", isDirectory: true)
         do {
             try await fetchOTAResource(channel: channel)
-            let cachedBaseURL = documentsDirectory.appendingPathComponent("cache")
-            try await loadResource(url: cachedBaseURL, channel: channel)
         } catch {
             logError("关卡数据获取失败: \(error.localizedDescription)")
         }
+
+        do {
+            try await loadResource(url: cachedBaseURL, channel: channel)
+        } catch {
+            logError("缓存资源加载失败: \(error.localizedDescription)")
+        }
+        reloadStageCatalog(at: cachedBaseURL)
 
         #if DEBUG
         guard false else { return }
@@ -408,6 +416,23 @@ extension MAAViewModel {
         }
     }
 
+    private func reloadStageCatalog(at cacheURL: URL) {
+        let url = cacheURL.appendingPathComponent("gui/StageActivityV2.json", isDirectory: false)
+        guard let data = try? Data(contentsOf: url) else {
+            stageCatalog = StageCatalog()
+            resetUnavailableFightStages(now: Date())
+            return
+        }
+
+        do {
+            stageCatalog = try StageCatalog(data: data)
+        } catch {
+            stageCatalog = StageCatalog()
+            logError("活动关卡数据解析失败: \(error.localizedDescription)")
+        }
+        resetUnavailableFightStages(now: Date())
+    }
+
     private func handleEarlyReturn(backTo: Status) {
         if status == .pending {
             status = backTo
@@ -436,9 +461,14 @@ extension MAAViewModel {
     func tryStartTasks() async {
         do {
             try await startTasks()
-        } catch {
+        } catch MAAError.fightTaskAppendFailed(let stage) {
+            logError("无法添加刷理智任务：关卡 \(stage) 或其他任务参数无效")
+            logInfo("请检查手动输入的关卡名和刷理智设置，或改用关卡选择器")
+        } catch MaaCoreError.connectFailed {
             logError("ConnectFailed")
             logInfo("CheckSettings")
+        } catch {
+            logError("任务启动失败：\(error.localizedDescription)")
         }
     }
 
@@ -472,19 +502,56 @@ extension MAAViewModel {
             tasks[index] = .init(id: task.id, task: .closedown(config), enabled: task.enabled)
         }
 
+        resetUnavailableFightStages(now: Date())
+
         try await ensureHandle()
 
         for task in tasks {
             guard task.enabled else { continue }
 
-            if let coreID = try await handle?.appendTask(task.task) {
-                taskIDMap[coreID] = task.id
+            do {
+                if let coreID = try await handle?.appendTask(task.task) {
+                    taskIDMap[coreID] = task.id
+                }
+            } catch MaaCoreError.appendTaskFailed {
+                discardHandleAfterAppendFailure()
+                if case .fight(let config) = task.task {
+                    throw MAAError.fightTaskAppendFailed(config.stage)
+                }
+                throw MaaCoreError.appendTaskFailed
             }
         }
 
         try await handle?.start()
 
         status = .busy
+    }
+
+    private func discardHandleAfterAppendFailure() {
+        messageTask?.cancel()
+        messageTask = nil
+        handle = nil
+        taskIDMap.removeAll()
+        taskStatus.removeAll()
+    }
+
+    private func resetUnavailableFightStages(now: Date) {
+        let server = StageServer(channelRawValue: clientChannel.rawValue)
+        for (index, task) in tasks.enumerated() {
+            guard task.enabled, case .fight(var config) = task.task else { continue }
+
+            let previousStage = config.stage
+            let normalizedStage = stageCatalog.normalizedStageID(
+                previousStage,
+                server: server,
+                now: now,
+                coreVersion: MAAProvider.version)
+            guard normalizedStage != previousStage else { continue }
+
+            config.stage = normalizedStage
+            tasks[index] = .init(id: task.id, task: .fight(config), enabled: task.enabled)
+            logWarn("所选关卡 \(previousStage) 当前不可用，已重置为当前/上次")
+        }
     }
 
     private func initScheduledDailyTaskTimer() {

--- a/MeoAsstMac/Model/StageCatalog.swift
+++ b/MeoAsstMac/Model/StageCatalog.swift
@@ -1,0 +1,476 @@
+//
+//  StageCatalog.swift
+//  MAA
+//
+
+import Foundation
+
+enum StageServer: Equatable {
+    case official
+    case bilibili
+    case yoStarEN
+    case yoStarJP
+    case yoStarKR
+    case txwy
+
+    init(channelRawValue: String) {
+        switch channelRawValue {
+        case "Bilibili": self = .bilibili
+        case "YoStarEN": self = .yoStarEN
+        case "YoStarJP": self = .yoStarJP
+        case "YoStarKR": self = .yoStarKR
+        case "txwy": self = .txwy
+        default: self = .official
+        }
+    }
+
+    fileprivate var apiKey: String {
+        switch self {
+        case .official, .bilibili: "Official"
+        case .yoStarEN: "YoStarEN"
+        case .yoStarJP: "YoStarJP"
+        case .yoStarKR: "YoStarKR"
+        case .txwy: "txwy"
+        }
+    }
+
+    fileprivate var timeZoneOffset: Int {
+        switch self {
+        case .official, .bilibili, .txwy: 8
+        case .yoStarEN: -7
+        case .yoStarJP, .yoStarKR: 9
+        }
+    }
+}
+
+enum StageKind: Equatable {
+    case permanent
+    case resource
+    case chip
+    case sideStory
+}
+
+struct StageActivity: Equatable {
+    let start: Date
+    let expire: Date
+}
+
+struct TodayStageActivity: Identifiable, Equatable {
+    let name: String
+    let expire: Date
+
+    var id: String { "\(name)-\(expire.timeIntervalSince1970)" }
+}
+
+struct TodayStageSummary: Equatable {
+    let localizedTipKeys: [String]
+    let activities: [TodayStageActivity]
+}
+
+struct StageDescriptor: Identifiable, Equatable {
+    let id: String
+    let display: String
+    let kind: StageKind
+    let openWeekdays: Set<Int>?
+    let activity: StageActivity?
+    let activityName: String?
+    let minimumRequired: String?
+    let tipKey: String?
+
+    init(
+        id: String,
+        display: String? = nil,
+        kind: StageKind,
+        openWeekdays: Set<Int>? = nil,
+        activity: StageActivity? = nil,
+        activityName: String? = nil,
+        minimumRequired: String? = nil,
+        tipKey: String? = nil
+    ) {
+        self.id = id
+        self.display = display ?? id
+        self.kind = kind
+        self.openWeekdays = openWeekdays
+        self.activity = activity
+        self.activityName = activityName
+        self.minimumRequired = minimumRequired
+        self.tipKey = tipKey
+    }
+}
+
+enum StageAvailability: Equatable {
+    case open
+    case closedForWeeklySchedule
+    case activityNotStarted
+    case activityExpired
+    case unsupportedCoreVersion(required: String)
+
+    var isOpen: Bool { self == .open }
+}
+
+struct StageCatalog {
+    private let clients: [String: StageActivityClient]
+
+    init() {
+        clients = [:]
+    }
+
+    init(data: Data) throws {
+        clients = try JSONDecoder().decode(StageActivityDocument.self, from: data).clients
+    }
+
+    func stages(for server: StageServer) -> [StageDescriptor] {
+        var result = Self.builtInStages
+        var knownValues = Set(result.map(\.id))
+
+        guard let client = clients[server.apiKey] else { return result }
+        for group in client.sideStories {
+            for stage in group.stages {
+                let activityPayload = stage.activity ?? group.activity
+                guard let activity = activityPayload.flatMap(Self.parseActivity) else { continue }
+                guard let value = stage.value, !value.isEmpty, knownValues.insert(value).inserted else { continue }
+                result.append(
+                    StageDescriptor(
+                        id: value,
+                        display: stage.display ?? value,
+                        kind: .sideStory,
+                        activity: activity,
+                        activityName: activityPayload?.stageName ?? group.activity?.stageName,
+                        minimumRequired: stage.minimumRequired ?? group.minimumRequired))
+            }
+        }
+        return result
+    }
+
+    func todaySummary(for server: StageServer, now: Date, coreVersion: String?) -> TodayStageSummary {
+        var localizedTipKeys: [String] = []
+        switch serverWeekday(for: server, now: now) {
+        case 1:
+            localizedTipKeys.append("周日了，记得打剿灭哦~")
+        case 2:
+            localizedTipKeys.append("周一了，可以打剿灭了~")
+        default:
+            break
+        }
+
+        localizedTipKeys.append(
+            contentsOf: stages(for: server).compactMap { stage in
+                guard stage.kind == .resource || stage.kind == .chip,
+                    availability(of: stage, server: server, now: now, coreVersion: coreVersion).isOpen
+                else {
+                    return nil
+                }
+                return stage.tipKey
+            })
+
+        var activities: [TodayStageActivity] = []
+        var knownActivities = Set<String>()
+        if let resourceCollection = clients[server.apiKey]?.resourceCollection,
+            let name = resourceCollection.tip,
+            !name.isEmpty,
+            let activity = Self.parseActivity(resourceCollection),
+            activity.start <= now,
+            now <= activity.expire
+        {
+            activities.append(TodayStageActivity(name: name, expire: activity.expire))
+            knownActivities.insert(name)
+        }
+
+        for stage in stages(for: server) where stage.kind == .sideStory {
+            guard availability(of: stage, server: server, now: now, coreVersion: coreVersion).isOpen,
+                let name = stage.activityName,
+                !name.isEmpty,
+                knownActivities.insert(name).inserted,
+                let activity = stage.activity
+            else {
+                continue
+            }
+            activities.append(TodayStageActivity(name: name, expire: activity.expire))
+        }
+
+        return TodayStageSummary(localizedTipKeys: localizedTipKeys, activities: activities)
+    }
+
+    func availability(
+        of stage: StageDescriptor,
+        server: StageServer,
+        now: Date,
+        coreVersion: String?
+    ) -> StageAvailability {
+        switch stage.kind {
+        case .permanent:
+            return .open
+
+        case .resource, .chip:
+            if resourceCollectionIsOpen(for: server, now: now) {
+                return .open
+            }
+            guard let openWeekdays = stage.openWeekdays, !openWeekdays.isEmpty else { return .open }
+            return openWeekdays.contains(serverWeekday(for: server, now: now))
+                ? .open
+                : .closedForWeeklySchedule
+
+        case .sideStory:
+            guard let activity = stage.activity else { return .activityExpired }
+            if now < activity.start { return .activityNotStarted }
+            if now > activity.expire { return .activityExpired }
+
+            if let required = stage.minimumRequired {
+                if coreVersion == "DEBUG_VERSION" { return .open }
+                guard let requiredVersion = SemanticVersion(required),
+                    let coreVersion,
+                    let currentVersion = SemanticVersion(coreVersion),
+                    currentVersion >= requiredVersion
+                else {
+                    return .unsupportedCoreVersion(required: required)
+                }
+            }
+            return .open
+        }
+    }
+
+    func normalizedStageID(
+        _ stageID: String,
+        server: StageServer,
+        now: Date,
+        coreVersion: String?
+    ) -> String {
+        guard let stage = stages(for: server).first(where: { $0.id == stageID }) else {
+            return stageID
+        }
+        return availability(of: stage, server: server, now: now, coreVersion: coreVersion).isOpen ? stageID : ""
+    }
+
+    static func builtInDisplayName(for stageID: String) -> String? {
+        builtInStages.first(where: { $0.id == stageID })?.display
+    }
+
+    func serverWeekday(for server: StageServer, now: Date) -> Int {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: server.timeZoneOffset * 3600)!
+        return calendar.component(.weekday, from: now.addingTimeInterval(-4 * 3600))
+    }
+
+    private func resourceCollectionIsOpen(for server: StageServer, now: Date) -> Bool {
+        guard let payload = clients[server.apiKey]?.resourceCollection,
+            payload.isResourceCollection == true,
+            let activity = Self.parseActivity(payload)
+        else {
+            return false
+        }
+        return activity.start <= now && now <= activity.expire
+    }
+
+    private static func parseActivity(_ payload: StageActivityPayload) -> StageActivity? {
+        guard let start = payload.utcStartTime,
+            let expire = payload.utcExpireTime,
+            let offset = payload.timeZone,
+            (-18...18).contains(offset)
+        else {
+            return nil
+        }
+
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: offset * 3600)
+        formatter.dateFormat = "yyyy/MM/dd HH:mm:ss"
+
+        guard let startDate = formatter.date(from: start), let expireDate = formatter.date(from: expire) else {
+            return nil
+        }
+        return StageActivity(start: startDate, expire: expireDate)
+    }
+
+    private static let builtInStages: [StageDescriptor] = [
+        StageDescriptor(id: "", display: "当前/上次", kind: .permanent),
+        StageDescriptor(id: "1-7", kind: .permanent),
+        StageDescriptor(id: "Annihilation", display: "剿灭模式", kind: .permanent),
+        StageDescriptor(
+            id: "CE-6", kind: .resource, openWeekdays: [1, 3, 5, 7], tipKey: "CE-6: 龙门币"),
+        StageDescriptor(id: "AP-5", kind: .resource, openWeekdays: [1, 2, 5, 7], tipKey: "AP-5: 红票"),
+        StageDescriptor(id: "CA-5", kind: .resource, openWeekdays: [1, 3, 4, 6], tipKey: "CA-5: 技能"),
+        StageDescriptor(id: "LS-6", kind: .resource, tipKey: "LS-6: 经验"),
+        StageDescriptor(id: "SK-5", kind: .resource, openWeekdays: [2, 4, 6, 7], tipKey: "SK-5: 碳"),
+        StageDescriptor(
+            id: "PR-A-1", display: "奶/盾芯片", kind: .chip, openWeekdays: [1, 2, 5, 6],
+            tipKey: "PR-A-1/2: 奶/盾芯片"),
+        StageDescriptor(id: "PR-A-2", display: "奶/盾芯片组", kind: .chip, openWeekdays: [1, 2, 5, 6]),
+        StageDescriptor(
+            id: "PR-B-1", display: "术/狙芯片", kind: .chip, openWeekdays: [2, 3, 6, 7],
+            tipKey: "PR-B-1/2: 术/狙芯片"),
+        StageDescriptor(id: "PR-B-2", display: "术/狙芯片组", kind: .chip, openWeekdays: [2, 3, 6, 7]),
+        StageDescriptor(
+            id: "PR-C-1", display: "先/辅芯片", kind: .chip, openWeekdays: [1, 4, 5, 7],
+            tipKey: "PR-C-1/2: 先/辅芯片"),
+        StageDescriptor(id: "PR-C-2", display: "先/辅芯片组", kind: .chip, openWeekdays: [1, 4, 5, 7]),
+        StageDescriptor(
+            id: "PR-D-1", display: "近/特芯片", kind: .chip, openWeekdays: [1, 3, 4, 7],
+            tipKey: "PR-D-1/2: 近/特芯片"),
+        StageDescriptor(id: "PR-D-2", display: "近/特芯片组", kind: .chip, openWeekdays: [1, 3, 4, 7]),
+    ]
+}
+
+private struct StageActivityDocument: Decodable {
+    let clients: [String: StageActivityClient]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+        var clients: [String: StageActivityClient] = [:]
+        for key in container.allKeys {
+            if let client = try? container.decode(StageActivityClient.self, forKey: key) {
+                clients[key.stringValue] = client
+            }
+        }
+        self.clients = clients
+    }
+}
+
+private struct StageActivityClient: Decodable {
+    let sideStories: [StageActivityGroup]
+    let resourceCollection: StageActivityPayload?
+
+    private enum CodingKeys: String, CodingKey {
+        case sideStoryStage
+        case resourceCollection
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        resourceCollection = try? container.decode(StageActivityPayload.self, forKey: .resourceCollection)
+
+        guard
+            let sideStoryContainer = try? container.nestedContainer(
+                keyedBy: DynamicCodingKey.self, forKey: .sideStoryStage)
+        else {
+            sideStories = []
+            return
+        }
+
+        sideStories = sideStoryContainer.allKeys.compactMap {
+            try? sideStoryContainer.decode(StageActivityGroup.self, forKey: $0)
+        }
+    }
+}
+
+private struct StageActivityGroup: Decodable {
+    let minimumRequired: String?
+    let activity: StageActivityPayload?
+    let stages: [StageActivityStagePayload]
+
+    private enum CodingKeys: String, CodingKey {
+        case minimumRequired = "MinimumRequired"
+        case activity = "Activity"
+        case stages = "Stages"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        minimumRequired = try? container.decode(String.self, forKey: .minimumRequired)
+        activity = try? container.decode(StageActivityPayload.self, forKey: .activity)
+        stages = (try? container.decode([StageActivityStagePayload].self, forKey: .stages)) ?? []
+    }
+}
+
+private struct StageActivityStagePayload: Decodable {
+    let display: String?
+    let value: String?
+    let minimumRequired: String?
+    let activity: StageActivityPayload?
+
+    private enum CodingKeys: String, CodingKey {
+        case display = "Display"
+        case value = "Value"
+        case minimumRequired = "MinimumRequired"
+        case activity = "Activity"
+    }
+}
+
+private struct StageActivityPayload: Decodable {
+    let utcStartTime: String?
+    let utcExpireTime: String?
+    let timeZone: Int?
+    let isResourceCollection: Bool?
+    let tip: String?
+    let stageName: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case utcStartTime = "UtcStartTime"
+        case utcExpireTime = "UtcExpireTime"
+        case timeZone = "TimeZone"
+        case isResourceCollection = "IsResourceCollection"
+        case tip = "Tip"
+        case stageName = "StageName"
+    }
+}
+
+private struct DynamicCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int? = nil
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(intValue: Int) {
+        stringValue = String(intValue)
+    }
+}
+
+private struct SemanticVersion: Comparable {
+    let core: [Int]
+    private let prerelease: [Identifier]?
+
+    init?(_ rawValue: String) {
+        let value = rawValue.hasPrefix("v") ? String(rawValue.dropFirst()) : rawValue
+        let parts = value.split(separator: "-", maxSplits: 1).map(String.init)
+        let coreParts = parts[0].split(separator: ".")
+        guard coreParts.count >= 2, coreParts.allSatisfy({ Int($0) != nil }) else { return nil }
+
+        core = coreParts.map { Int($0)! }
+        prerelease =
+            parts.count == 2
+            ? parts[1].split(separator: ".").map { Identifier(String($0)) }
+            : nil
+    }
+
+    static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        let length = max(lhs.core.count, rhs.core.count)
+        for index in 0..<length {
+            let left = index < lhs.core.count ? lhs.core[index] : 0
+            let right = index < rhs.core.count ? rhs.core[index] : 0
+            if left != right { return left < right }
+        }
+
+        switch (lhs.prerelease, rhs.prerelease) {
+        case (nil, nil): return false
+        case (nil, _): return false
+        case (_, nil): return true
+        case (.some(let left), .some(let right)):
+            for index in 0..<max(left.count, right.count) {
+                guard index < left.count else { return true }
+                guard index < right.count else { return false }
+                if left[index] != right[index] { return left[index] < right[index] }
+            }
+            return false
+        }
+    }
+
+    private enum Identifier: Comparable {
+        case number(Int)
+        case text(String)
+
+        init(_ value: String) {
+            self = Int(value).map(Self.number) ?? .text(value)
+        }
+
+        static func < (lhs: Identifier, rhs: Identifier) -> Bool {
+            switch (lhs, rhs) {
+            case (.number(let left), .number(let right)): left < right
+            case (.number, .text): true
+            case (.text, .number): false
+            case (.text(let left), .text(let right)): left < right
+            }
+        }
+    }
+}

--- a/MeoAsstMac/Navigation/TasksContent.swift
+++ b/MeoAsstMac/Navigation/TasksContent.swift
@@ -12,30 +12,35 @@ struct TasksContent: View {
     @Binding var selection: UUID?
 
     var body: some View {
-        List(selection: $selection) {
-            ForEach($viewModel.tasks, id: \.id) { $task in
-                switch task.task {
-                case .startup(let config):
-                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
-                case .closedown(let config):
-                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
-                case .recruit(let config):
-                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
-                case .infrast(let config):
-                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
-                case .fight(let config):
-                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
-                case .mall(let config):
-                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
-                case .award(let config):
-                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
-                case .roguelike(let config):
-                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
-                case .reclamation(let config):
-                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
+        VStack(spacing: 0) {
+            List(selection: $selection) {
+                ForEach($viewModel.tasks, id: \.id) { $task in
+                    switch task.task {
+                    case .startup(let config):
+                        TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                    case .closedown(let config):
+                        TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                    case .recruit(let config):
+                        TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                    case .infrast(let config):
+                        TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                    case .fight(let config):
+                        TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                    case .mall(let config):
+                        TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                    case .award(let config):
+                        TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                    case .roguelike(let config):
+                        TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                    case .reclamation(let config):
+                        TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                    }
                 }
+                .onMove(perform: moveTask)
             }
-            .onMove(perform: moveTask)
+
+            Divider()
+            TodayStageTipView()
         }
         .onChange(of: selection, perform: updateViewMode)
         .toolbar(content: listToolbar)

--- a/MeoAsstMac/Navigation/TodayStageTipView.swift
+++ b/MeoAsstMac/Navigation/TodayStageTipView.swift
@@ -1,0 +1,57 @@
+//
+//  TodayStageTipView.swift
+//  MAA
+//
+
+import SwiftUI
+
+struct TodayStageTipView: View {
+    @EnvironmentObject private var viewModel: MAAViewModel
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 60)) { context in
+            let summary = viewModel.stageCatalog.todaySummary(
+                for: StageServer(channelRawValue: viewModel.clientChannel.rawValue),
+                now: context.date,
+                coreVersion: MAAProvider.version)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("今日关卡小提示")
+                        .font(.headline)
+                    Spacer()
+                    Image(systemName: "questionmark.circle")
+                        .foregroundStyle(.secondary)
+                        .help("关卡开放状态按当前服务器时区及凌晨 4 点刷新")
+                }
+
+                ForEach(summary.localizedTipKeys, id: \.self) { key in
+                    Text(LocalizedStringKey(key))
+                }
+
+                ForEach(summary.activities) { activity in
+                    if remainingDays(until: activity.expire, now: context.date) > 0 {
+                        Text(
+                            "「\(activity.name)」剩余 \(remainingDays(until: activity.expire, now: context.date)) 天")
+                    } else {
+                        Text("「\(activity.name)」剩余不到 1 天")
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+        }
+    }
+
+    private func remainingDays(until expire: Date, now: Date) -> Int {
+        max(0, Int(expire.timeIntervalSince(now) / 86_400))
+    }
+}
+
+struct TodayStageTipView_Previews: PreviewProvider {
+    static var previews: some View {
+        TodayStageTipView()
+            .environmentObject(MAAViewModel())
+            .frame(width: 260)
+    }
+}

--- a/MeoAsstMac/Task Configurations/FightConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/FightConfiguration.swift
@@ -31,6 +31,8 @@ struct FightConfiguration: MAATaskConfiguration {
     var subtitle: String {
         if stage == "" {
             return String(localized: "当前/上次")
+        } else if let display = StageCatalog.builtInDisplayName(for: stage) {
+            return String(localized: String.LocalizationValue(display))
         } else {
             return stage
         }

--- a/MeoAsstMacTests/StageCatalogTests.swift
+++ b/MeoAsstMacTests/StageCatalogTests.swift
@@ -1,0 +1,219 @@
+import XCTest
+
+final class StageCatalogTests: XCTestCase {
+    func testBuiltInWeeklySchedules() throws {
+        let catalog = StageCatalog()
+        let stages = Dictionary(uniqueKeysWithValues: catalog.stages(for: .official).map { ($0.id, $0) })
+        let expected: [String: Set<Int>] = [
+            "CE-6": [1, 3, 5, 7],
+            "AP-5": [1, 2, 5, 7],
+            "CA-5": [1, 3, 4, 6],
+            "SK-5": [2, 4, 6, 7],
+            "PR-A-1": [1, 2, 5, 6],
+            "PR-A-2": [1, 2, 5, 6],
+            "PR-B-1": [2, 3, 6, 7],
+            "PR-B-2": [2, 3, 6, 7],
+            "PR-C-1": [1, 4, 5, 7],
+            "PR-C-2": [1, 4, 5, 7],
+            "PR-D-1": [1, 3, 4, 7],
+            "PR-D-2": [1, 3, 4, 7],
+        ]
+
+        for (stage, weekdays) in expected {
+            XCTAssertEqual(try XCTUnwrap(stages[stage]).openWeekdays, weekdays, stage)
+        }
+        XCTAssertNil(try XCTUnwrap(stages["LS-6"]).openWeekdays)
+    }
+
+    func testServerDayChangesAtFourForEveryTimezone() throws {
+        let catalog = StageCatalog()
+        for (server, offset) in [(StageServer.official, 8), (.yoStarJP, 9), (.yoStarEN, -7)] {
+            let before = try date("2026/07/13 03:59:59", offset: offset)
+            let boundary = try date("2026/07/13 04:00:00", offset: offset)
+            XCTAssertEqual(catalog.serverWeekday(for: server, now: before), 1)
+            XCTAssertEqual(catalog.serverWeekday(for: server, now: boundary), 2)
+        }
+    }
+
+    func testResourceCollectionOverridesWeeklyScheduleInclusively() throws {
+        let catalog = try StageCatalog(data: Data(resourceCollectionJSON.utf8))
+        let ap = try XCTUnwrap(catalog.stages(for: .official).first { $0.id == "AP-5" })
+        let before = try date("2026/07/13 03:59:59", offset: 8)
+        let start = try date("2026/07/13 04:00:00", offset: 8)
+        let expire = try date("2026/07/14 03:59:59", offset: 8)
+        let after = try date("2026/07/14 04:00:00", offset: 8)
+
+        XCTAssertEqual(catalog.availability(of: ap, server: .official, now: before, coreVersion: nil), .open)
+        XCTAssertEqual(catalog.availability(of: ap, server: .official, now: start, coreVersion: nil), .open)
+        XCTAssertEqual(catalog.availability(of: ap, server: .official, now: expire, coreVersion: nil), .open)
+        XCTAssertEqual(
+            catalog.availability(of: ap, server: .official, now: after, coreVersion: nil),
+            .closedForWeeklySchedule)
+    }
+
+    func testBilibiliUsesOfficialActivities() throws {
+        let catalog = try StageCatalog(data: Data(sideStoryJSON.utf8))
+        XCTAssertTrue(catalog.stages(for: .bilibili).contains { $0.id == "EV-8" })
+    }
+
+    func testSideStoryActivityWindowAndMinimumVersion() throws {
+        let catalog = try StageCatalog(data: Data(sideStoryJSON.utf8))
+        let stage = try XCTUnwrap(catalog.stages(for: .official).first { $0.id == "EV-8" })
+        let before = try date("2026/07/12 15:59:59", offset: 8)
+        let start = try date("2026/07/12 16:00:00", offset: 8)
+        let expire = try date("2026/07/20 03:59:59", offset: 8)
+        let after = try date("2026/07/20 04:00:00", offset: 8)
+
+        XCTAssertEqual(
+            catalog.availability(of: stage, server: .official, now: before, coreVersion: "v6.12.0"),
+            .activityNotStarted)
+        XCTAssertEqual(
+            catalog.availability(of: stage, server: .official, now: start, coreVersion: "v6.11.9"),
+            .unsupportedCoreVersion(required: "v6.12.0-beta.2"))
+        XCTAssertEqual(
+            catalog.availability(of: stage, server: .official, now: start, coreVersion: "v6.12.0-beta.1"),
+            .unsupportedCoreVersion(required: "v6.12.0-beta.2"))
+        XCTAssertEqual(
+            catalog.availability(of: stage, server: .official, now: start, coreVersion: "v6.12.0"), .open)
+        XCTAssertEqual(
+            catalog.availability(of: stage, server: .official, now: start, coreVersion: "DEBUG_VERSION"), .open)
+        XCTAssertEqual(
+            catalog.availability(of: stage, server: .official, now: expire, coreVersion: "v6.12.0"), .open)
+        XCTAssertEqual(
+            catalog.availability(of: stage, server: .official, now: after, coreVersion: "v6.12.0"),
+            .activityExpired)
+    }
+
+    func testMalformedActivityGroupDoesNotDiscardValidGroup() throws {
+        let json = sideStoryJSON.replacingOccurrences(
+            of: "\"sideStoryStage\": {",
+            with: "\"sideStoryStage\": { \"Broken\": 42,")
+        let catalog = try StageCatalog(data: Data(json.utf8))
+        XCTAssertTrue(catalog.stages(for: .official).contains { $0.id == "EV-8" })
+    }
+
+    func testStageLevelMinimumVersionOverridesGroup() throws {
+        let catalog = try StageCatalog(data: Data(sideStoryJSON.utf8))
+        let stage = try XCTUnwrap(catalog.stages(for: .official).first { $0.id == "EV-7" })
+        let now = try date("2026/07/22 12:00:00", offset: 8)
+        XCTAssertEqual(
+            catalog.availability(of: stage, server: .official, now: now, coreVersion: "v6.12.0"),
+            .unsupportedCoreVersion(required: "v6.13.0"))
+    }
+
+    func testStageLevelActivityOverridesGroupActivity() throws {
+        let catalog = try StageCatalog(data: Data(sideStoryJSON.utf8))
+        let stage = try XCTUnwrap(catalog.stages(for: .official).first { $0.id == "EV-7" })
+        let afterGroupExpired = try date("2026/07/22 12:00:00", offset: 8)
+
+        XCTAssertEqual(
+            catalog.availability(of: stage, server: .official, now: afterGroupExpired, coreVersion: "v6.13.0"),
+            .open)
+        XCTAssertEqual(stage.activityName, "Event Rerun")
+        XCTAssertEqual(stage.activity?.expire, try date("2026/07/30 03:59:59", offset: 8))
+    }
+
+    func testUnavailableKnownStageIsNormalizedButCustomStageIsPreserved() throws {
+        let catalog = StageCatalog()
+        let tuesday = try date("2026/07/14 12:00:00", offset: 8)
+
+        XCTAssertEqual(
+            catalog.normalizedStageID("AP-5", server: .official, now: tuesday, coreVersion: nil), "")
+        XCTAssertEqual(
+            catalog.normalizedStageID("CE-6", server: .official, now: tuesday, coreVersion: nil), "CE-6")
+        XCTAssertEqual(
+            catalog.normalizedStageID("AveMujica-8", server: .official, now: tuesday, coreVersion: nil),
+            "AveMujica-8")
+    }
+
+    func testChipStageDisplayNamesDescribeProfessions() {
+        XCTAssertEqual(StageCatalog.builtInDisplayName(for: "PR-A-1"), "奶/盾芯片")
+        XCTAssertEqual(StageCatalog.builtInDisplayName(for: "PR-B-2"), "术/狙芯片组")
+        XCTAssertEqual(StageCatalog.builtInDisplayName(for: "PR-C-1"), "先/辅芯片")
+        XCTAssertEqual(StageCatalog.builtInDisplayName(for: "PR-D-2"), "近/特芯片组")
+    }
+
+    func testTodaySummaryUsesServerDayAndCombinesChipStages() throws {
+        let catalog = StageCatalog()
+        let monday = try date("2026/07/13 12:00:00", offset: 8)
+        let summary = catalog.todaySummary(for: .official, now: monday, coreVersion: nil)
+
+        XCTAssertEqual(
+            summary.localizedTipKeys,
+            [
+                "周一了，可以打剿灭了~",
+                "AP-5: 红票",
+                "LS-6: 经验",
+                "SK-5: 碳",
+                "PR-A-1/2: 奶/盾芯片",
+                "PR-B-1/2: 术/狙芯片",
+            ])
+    }
+
+    func testTodaySummaryDeduplicatesActivityName() throws {
+        let catalog = try StageCatalog(data: Data(sideStoryJSON.utf8))
+        let now = try date("2026/07/13 12:00:00", offset: 8)
+        let summary = catalog.todaySummary(for: .official, now: now, coreVersion: "v6.13.0")
+
+        XCTAssertEqual(summary.activities.count, 1)
+        XCTAssertEqual(summary.activities.first?.name, "Event Name")
+    }
+
+    private func date(_ value: String, offset: Int) throws -> Date {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: offset * 3600)
+        formatter.dateFormat = "yyyy/MM/dd HH:mm:ss"
+        return try XCTUnwrap(formatter.date(from: value))
+    }
+
+    private var resourceCollectionJSON: String {
+        """
+        {
+          "Official": {
+            "resourceCollection": {
+              "UtcStartTime": "2026/07/13 04:00:00",
+              "UtcExpireTime": "2026/07/14 03:59:59",
+              "TimeZone": 8,
+              "IsResourceCollection": true
+            }
+          }
+        }
+        """
+    }
+
+    private var sideStoryJSON: String {
+        """
+        {
+          "Official": {
+            "sideStoryStage": {
+              "Event": {
+                "MinimumRequired": "v6.10.0",
+                "Activity": {
+                  "StageName": "Event Name",
+                  "UtcStartTime": "2026/07/12 16:00:00",
+                  "UtcExpireTime": "2026/07/20 03:59:59",
+                  "TimeZone": 8
+                },
+                "Stages": [
+                  { "Display": "Event 8", "Value": "EV-8", "MinimumRequired": "v6.12.0-beta.2" },
+                  {
+                    "Display": "Event 7",
+                    "Value": "EV-7",
+                    "MinimumRequired": "v6.13.0",
+                    "Activity": {
+                      "StageName": "Event Rerun",
+                      "UtcStartTime": "2026/07/21 16:00:00",
+                      "UtcExpireTime": "2026/07/30 03:59:59",
+                      "TimeZone": 8
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+        """
+    }
+}

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -202,6 +202,7 @@
       }
     },
     "AP-5" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ko" : {
           "stringUnit" : {
@@ -286,6 +287,7 @@
       }
     },
     "CA-5" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ko" : {
           "stringUnit" : {
@@ -305,6 +307,7 @@
       "shouldTranslate" : false
     },
     "CE-6" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ko" : {
           "stringUnit" : {
@@ -1054,6 +1057,7 @@
       }
     },
     "LS-6" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ko" : {
           "stringUnit" : {
@@ -2548,6 +2552,7 @@
       }
     },
     "剿灭模式" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ko" : {
           "stringUnit" : {
@@ -3114,7 +3119,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "현재 난이도"
+            "value" : "오늘의 자원 스테이지"
           }
         }
       }
@@ -4928,6 +4933,609 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "기본 교대"
+          }
+        }
+      }
+    },
+    "AP-5: 红票" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AP-5: Purchase Certificate"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AP-5: 구매증명서"
+          }
+        }
+      }
+    },
+    "CA-5: 技能" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CA-5: Skill Summary"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CA-5: 스킬개론"
+          }
+        }
+      }
+    },
+    "CE-6: 龙门币" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CE-6: LMD"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CE-6: 용문폐"
+          }
+        }
+      }
+    },
+    "LS-6: 经验" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LS-6: Battle Record"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LS-6: 작전기록"
+          }
+        }
+      }
+    },
+    "PR-A-1/2: 奶/盾芯片" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PR-A-1/2: Medic/Defender Chip"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PR-A-1/2: 메딕/디펜더 칩"
+          }
+        }
+      }
+    },
+    "PR-B-1/2: 术/狙芯片" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PR-B-1/2: Caster/Sniper Chip"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PR-B-1/2: 캐스터/스나이퍼 칩"
+          }
+        }
+      }
+    },
+    "PR-C-1/2: 先/辅芯片" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PR-C-1/2: Vanguard/Supporter Chip"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PR-C-1/2: 뱅가드/서포터 칩"
+          }
+        }
+      }
+    },
+    "PR-D-1/2: 近/特芯片" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PR-D-1/2: Guard/Specialist Chip"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PR-D-1/2: 가드/스페셜리스트 칩"
+          }
+        }
+      }
+    },
+    "SK-5: 碳" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SK-5: Carbon"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SK-5: 탄소"
+          }
+        }
+      }
+    },
+    "周一了，可以打剿灭了~" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "It's Monday: time to clear Annihilation~"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "월요일입니다. 섬멸 작전을 진행할 수 있어요~"
+          }
+        }
+      }
+    },
+    "周日了，记得打剿灭哦~" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "It's Sunday: don't forget Annihilation~"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일요일입니다. 섬멸 작전을 잊지 마세요~"
+          }
+        }
+      }
+    },
+    "SK-5" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SK-5"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SK-5 (카본)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "碳-5"
+          }
+        }
+      }
+    },
+    "「%@」剩余 %lld 天" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"%1$@\" has %2$lld days remaining"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%1$@」 종료까지 %2$lld일"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "「%1$@」剩余 %2$lld 天"
+          }
+        }
+      }
+    },
+    "「%@」剩余不到 1 天" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"%@\" has less than 1 day remaining"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」 종료까지 1일 미만"
+          }
+        }
+      }
+    },
+    "今日关卡小提示" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today's Stage Tips"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘의 스테이지 팁"
+          }
+        }
+      }
+    },
+    "今日未开放" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unavailable Today"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 개방되지 않음"
+          }
+        }
+      }
+    },
+    "今日资源本" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today's Supplies"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘의 자원 스테이지"
+          }
+        }
+      }
+    },
+    "任务启动失败：%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to start tasks: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 시작 실패: %@"
+          }
+        }
+      }
+    },
+    "先/辅芯片" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vanguard/Supporter Chip"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "뱅가드/서포터 칩"
+          }
+        }
+      }
+    },
+    "先/辅芯片组" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vanguard/Supporter Chip Pack"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "뱅가드/서포터 칩셋"
+          }
+        }
+      }
+    },
+    "关卡开放状态按当前服务器时区及凌晨 4 点刷新" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stage availability refreshes at 04:00 in the selected server's time zone"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스테이지 개방 상태는 선택한 서버 시간대의 오전 4시에 갱신됩니다"
+          }
+        }
+      }
+    },
+    "奶/盾芯片" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medic/Defender Chip"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메딕/디펜더 칩"
+          }
+        }
+      }
+    },
+    "奶/盾芯片组" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medic/Defender Chip Pack"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메딕/디펜더 칩셋"
+          }
+        }
+      }
+    },
+    "常用关卡" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Common Stages"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자주 쓰는 스테이지"
+          }
+        }
+      }
+    },
+    "所选关卡 %@ 今日未开放，执行前将自动重置为当前/上次" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The selected stage %@ is unavailable today and will be reset to Current/Last before running"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택한 스테이지 %@은(는) 오늘 개방되지 않아 실행 전에 현재/최근으로 초기화됩니다"
+          }
+        }
+      }
+    },
+    "所选关卡 %@ 当前不可用，已重置为当前/上次" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selected stage %@ is currently unavailable and was reset to Current/Last"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택한 스테이지 %@을(를) 현재 이용할 수 없어 현재/최근으로 초기화했습니다"
+          }
+        }
+      }
+    },
+    "所选活动关卡 %@ 尚未开始或已经结束，执行前将自动重置为当前/上次" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The selected event stage %@ has not started or has ended and will be reset to Current/Last before running"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택한 이벤트 스테이지 %@은(는) 시작 전이거나 종료되어 실행 전에 현재/최근으로 초기화됩니다"
+          }
+        }
+      }
+    },
+    "所选活动关卡需要 MaaCore %@ 或更高版本" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The selected event stage requires MaaCore %@ or later."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택한 이벤트 스테이지에는 MaaCore %@ 이상이 필요합니다."
+          }
+        }
+      }
+    },
+    "无法添加刷理智任务：关卡 %@ 或其他任务参数无效" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to add Fight task: stage %@ or another task parameter is invalid"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이성 소모 작업을 추가할 수 없습니다: 스테이지 %@ 또는 다른 작업 매개변수가 올바르지 않습니다"
+          }
+        }
+      }
+    },
+    "显示今日未开放关卡" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Unavailable Stages"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘 미개방 스테이지 표시"
+          }
+        }
+      }
+    },
+    "术/狙芯片" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caster/Sniper Chip"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐스터/스나이퍼 칩"
+          }
+        }
+      }
+    },
+    "术/狙芯片组" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caster/Sniper Chip Pack"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐스터/스나이퍼 칩셋"
+          }
+        }
+      }
+    },
+    "活动关卡" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Event Stages"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이벤트 스테이지"
+          }
+        }
+      }
+    },
+    "活动关卡数据解析失败: %@" : {
+
+    },
+    "缓存资源加载失败: %@" : {
+
+    },
+    "请检查手动输入的关卡名和刷理智设置，或改用关卡选择器" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check the manually entered stage name and Fight settings, or use the stage picker"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "직접 입력한 스테이지 이름과 이성 소모 설정을 확인하거나 스테이지 선택기를 사용하세요"
+          }
+        }
+      }
+    },
+    "近/特芯片" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guard/Specialist Chip"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가드/스페셜리스트 칩"
+          }
+        }
+      }
+    },
+    "近/特芯片组" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guard/Specialist Chip Pack"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가드/스페셜리스트 칩셋"
           }
         }
       }


### PR DESCRIPTION
## 修改内容

为刷理智设置增加完整的关卡开放状态，并在任务列表底部增加基础版「今日关卡小提示」。

- 根据 `clientChannel` 使用对应服务器时区，并以服务器时间 `04:00` 作为换日边界
- 内置常驻资源本与 `PR-A/B/C/D` 芯片本的每周开放表
- 读取 `gui/StageActivityV2.json`，展示有效活动关卡，并支持 `resourceCollection` 期间资源本全部开放
- 关卡选择器按「常用 / 今日开放 / 活动 / 今日未开放」分组；芯片本显示职业简称
- 已持久化但今日关闭的已知关卡会在任务执行前自动重置为「当前/上次」
- API 请求失败时使用缓存和内置开放表，不阻断关卡选择
- 修复 `Fight` 参数追加失败被误报为连接失败的问题，并丢弃部分构造的 task handle
- 增加固定显示的「今日关卡小提示」，包含当日资源本、芯片本、周一/周日剿灭提醒和活动剩余时间

Related to MaaAssistantArknights/MaaAssistantArknights#9973.

本实现参考了 #42 的 SwiftUI 接入位置，但重新实现了日期、服务器时区、04:00 换日、活动数据、fallback 与测试逻辑。

## 验证

- [x] `MeoAsstMacTests`：12/12 tests passed
- [x] Debug arm64 build：`BUILD SUCCEEDED`
- [x] `swift-format lint --strict`（本次新增/实质修改的 Swift 文件）
- [x] `xcstringstool compile Resources/Localizable.xcstrings`
- [x] `git diff --check`
- [x] 真实客户端 UI smoke test：今日提示固定显示，切换到非刷理智详情时仍可见；周一开放关卡内容正确
- [x] 手工验证：关闭关卡持久化警告、执行前自动重置、非法手输关卡不再显示连接失败

## 本 PR 不包含

- 多个备选关卡按开放状态自动选择
- 活动材料库存/推荐刷取数量

这些可以在本 PR 的基础上单独迭代，避免扩大当前改动范围。

## Summary by Sourcery

在战斗设置和任务列表中支持“按服务器区分的关卡开放状态”和“每日关卡小提示”，同时加强任务启动错误处理并规范化关卡配置。

New Features:
- 引入一个由内置排期和 `StageActivityV2.json` 支持的关卡目录，用于根据服务器确定关卡开放状态和每日提示。
- 在战斗设置中新增分组关卡选择器，将常用关卡、今日开放关卡、活动关卡和今日关闭关卡分组显示，并可选展示当前不可用的素材/芯片关卡。
- 向应用暴露 MaaCore 版本，并在战斗配置副标题中使用内置的芯片关卡显示名称。
- 在任务列表下方常驻显示“今日关卡小提示”面板，总结今日推荐的素材/芯片关卡、剿灭作战提醒以及活动剩余天数。

Bug Fixes:
- 区分战斗任务参数追加失败与核心连接失败，并在任务启动失败时改进错误日志记录。
- 在任务执行前自动规范化并重置今日已关闭的已保存战斗关卡，避免出现无效的关卡配置。

Enhancements:
- 与 OTA 资源一同加载并刷新关卡目录，在活动数据缺失或异常时优雅回退。
- 收紧任务句柄生命周期，当追加任务失败时丢弃核心句柄并清理任务状态。
- 扩展任务列表布局，增加用于每日关卡小提示的固定底部区域，同时保留现有任务交互行为。

Tests:
- 添加 StageCatalog 单元测试，覆盖每周排期、服务器日 04:00 刷新、素材收集覆盖规则、别传活动时间窗口和版本门控、规范化行为以及每日总结生成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support server-aware stage availability and daily stage tips in fight settings and task list, while hardening task startup error handling and stage configuration normalization.

New Features:
- Introduce a stage catalog backed by built-in schedules and StageActivityV2.json to determine per-server stage availability and daily tips.
- Add a grouped stage picker in fight settings that separates common, today-open, event, and today-closed stages with optional display of unavailable resource/chip stages.
- Expose MaaCore version to the app and use built-in display names for chip stages in fight configuration subtitles.
- Show a persistent "今日关卡小提示" panel under the task list summarizing today’s recommended resource/chip stages, annihilation reminders, and remaining event days.

Bug Fixes:
- Distinguish fight task parameter append failures from core connection failures and improve error logging when task start fails.
- Automatically normalize and reset stored fight stages that are closed today before task execution to avoid invalid stage configurations.

Enhancements:
- Load and refresh stage catalog together with OTA resources, falling back gracefully when activity data is missing or malformed.
- Tighten task handle lifecycle by discarding the core handle and clearing task state when appending a task fails.
- Extend task list layout with a fixed bottom area for the daily stage tips while preserving existing task interactions.

Tests:
- Add StageCatalog unit tests covering weekly schedules, 04:00 server day rollover, resource collection overrides, side story activity windows and version gating, normalization behavior, and daily summary generation.

</details>

新功能：
- 从 `StageActivityV2.json` 中解析关卡目录，为素材和芯片关卡提供内置日程表，并处理按服务器划分的时间。
- 在战斗设置中引入分组关卡选择器，展示常用关卡、今日开放关卡、活动关卡以及今日关闭关卡，并可选显示当前不可挑战的关卡。
- 新增持久显示的每日关卡提示面板，总结今日推荐的素材/芯片关卡、剿灭作战提醒以及活动剩余时间。
- 将 MaaCore 版本暴露给应用，并在战斗配置中使用芯片关卡的内置显示名称。

错误修复：
- 避免将战斗参数追加失败错误误报为核心连接失败，并改进任务启动时的错误日志记录。
- 在任务执行前自动重置今日已关闭的已存储战斗关卡为当前/最近使用的关卡，防止出现无效的关卡配置。

改进：
- 与 OTA 资源一同加载并刷新关卡目录，当活动数据缺失或格式错误时提供回退方案。
- 收紧任务句柄生命周期，在追加失败时丢弃核心句柄并清除相关状态。
- 扩展任务列表布局，加入用于每日提示的固定底部区域，同时不干扰现有任务交互。

测试：
- 新增 `StageCatalog` 单元测试，覆盖每周日程、4:00 服务器日切换、素材收集覆盖规则、支线故事活动时间窗口和版本门控、规范化行为以及“今日摘要”的生成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在战斗设置和任务列表中支持“按服务器区分的关卡开放状态”和“每日关卡小提示”，同时加强任务启动错误处理并规范化关卡配置。

New Features:
- 引入一个由内置排期和 `StageActivityV2.json` 支持的关卡目录，用于根据服务器确定关卡开放状态和每日提示。
- 在战斗设置中新增分组关卡选择器，将常用关卡、今日开放关卡、活动关卡和今日关闭关卡分组显示，并可选展示当前不可用的素材/芯片关卡。
- 向应用暴露 MaaCore 版本，并在战斗配置副标题中使用内置的芯片关卡显示名称。
- 在任务列表下方常驻显示“今日关卡小提示”面板，总结今日推荐的素材/芯片关卡、剿灭作战提醒以及活动剩余天数。

Bug Fixes:
- 区分战斗任务参数追加失败与核心连接失败，并在任务启动失败时改进错误日志记录。
- 在任务执行前自动规范化并重置今日已关闭的已保存战斗关卡，避免出现无效的关卡配置。

Enhancements:
- 与 OTA 资源一同加载并刷新关卡目录，在活动数据缺失或异常时优雅回退。
- 收紧任务句柄生命周期，当追加任务失败时丢弃核心句柄并清理任务状态。
- 扩展任务列表布局，增加用于每日关卡小提示的固定底部区域，同时保留现有任务交互行为。

Tests:
- 添加 StageCatalog 单元测试，覆盖每周排期、服务器日 04:00 刷新、素材收集覆盖规则、别传活动时间窗口和版本门控、规范化行为以及每日总结生成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support server-aware stage availability and daily stage tips in fight settings and task list, while hardening task startup error handling and stage configuration normalization.

New Features:
- Introduce a stage catalog backed by built-in schedules and StageActivityV2.json to determine per-server stage availability and daily tips.
- Add a grouped stage picker in fight settings that separates common, today-open, event, and today-closed stages with optional display of unavailable resource/chip stages.
- Expose MaaCore version to the app and use built-in display names for chip stages in fight configuration subtitles.
- Show a persistent "今日关卡小提示" panel under the task list summarizing today’s recommended resource/chip stages, annihilation reminders, and remaining event days.

Bug Fixes:
- Distinguish fight task parameter append failures from core connection failures and improve error logging when task start fails.
- Automatically normalize and reset stored fight stages that are closed today before task execution to avoid invalid stage configurations.

Enhancements:
- Load and refresh stage catalog together with OTA resources, falling back gracefully when activity data is missing or malformed.
- Tighten task handle lifecycle by discarding the core handle and clearing task state when appending a task fails.
- Extend task list layout with a fixed bottom area for the daily stage tips while preserving existing task interactions.

Tests:
- Add StageCatalog unit tests covering weekly schedules, 04:00 server day rollover, resource collection overrides, side story activity windows and version gating, normalization behavior, and daily summary generation.

</details>

</details>