### PR TITLE
feat: 支持选择最高 10 倍代理倍率

### DIFF
--- a/MeoAsstMac/Configuration Views/FightSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/FightSettingsView.swift
@@ -56,7 +56,7 @@ struct FightSettingsView: View {
 
                 Picker(selection: $config.series) {
                     Text(verbatim: "AUTO").tag(0)
-                    ForEach((1...6).reversed(), id: \.self) { i in
+                    ForEach((1...10).reversed(), id: \.self) { i in
                         Text(verbatim: "\(i)").tag(i)
                     }
                     Text("不使用").tag(Int?.none)


### PR DESCRIPTION
将连战次数选项从1-6跟进到1-10

## Summary by Sourcery

新功能：
- 在战斗系列设置中，允许选择最多 10 场连续战斗，而不是 6 场。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Allow selecting up to 10 consecutive battles instead of 6 in the fight series setting.

</details>