### PR TITLE
feat: macOS 日志与任务状态显示对齐 Windows 版

### DIFF
--- a/MeoAsstMac/Core/MaaMessage.swift
+++ b/MeoAsstMac/Core/MaaMessage.swift
@@ -48,12 +48,14 @@ extension MAAViewModel {
 
         switch what {
         case "Connected":
-            break
+            isConnected = true
 
         case "UnsupportedResolution":
+            isConnected = false
             logError("ResolutionNotSupported")
 
         case "ResolutionError":
+            isConnected = false
             logError("ResolutionAcquisitionFailure")
 
         case "Reconnecting":
@@ -61,9 +63,11 @@ extension MAAViewModel {
             logError("TryToReconnect (\(times))")
 
         case "Reconnected":
+            isConnected = true
             logTrace("ReconnectSuccess")
 
         case "Disconnect":
+            isConnected = false
             logError("ReconnectFailed")
             if status == .idle {
                 break
@@ -77,6 +81,7 @@ extension MAAViewModel {
             logError("ScreencapFailed")
 
         case "TouchModeNotAvailable":
+            isConnected = false
             logError("TouchModeNotAvaiable")
 
         case "FastestWayToScreencap":
@@ -126,7 +131,7 @@ extension MAAViewModel {
                 taskStatus[id] = .cancel
             }
             resetStatus()
-            logTrace("Stopped")
+            log("Stopped", color: .trace, splitMode: .both)
 
         case .TaskChainError:
             if let id = taskID(taskDetails: message.details) {
@@ -175,7 +180,7 @@ extension MAAViewModel {
             break
 
         case .AllTasksCompleted:
-            logTrace("AllTasksComplete")
+            log("AllTasksComplete", color: .trace, splitMode: .both)
             resetStatus()
 
         default:
@@ -247,7 +252,7 @@ extension MAAViewModel {
 
             switch taskName {
             case "StartButton2", "AnnihilationConfirm":
-                logInfo("MissionStart \(execTimes) UnitTime")
+                log("MissionStart \(execTimes) UnitTime", color: .info, splitMode: .before)
 
             case "StoneConfirm":
                 logInfo("StoneUsed \(execTimes) UnitTime")
@@ -266,13 +271,13 @@ extension MAAViewModel {
 
             /// Tag: - 肉鸽相关
             case "StartExplore":
-                logInfo("BegunToExplore \(execTimes) UnitTime")
+                log("BegunToExplore \(execTimes) UnitTime", color: .info, splitMode: .before)
 
             case "StageTraderInvestConfirm":
                 logInfo("HasInvested \(execTimes) UnitTime")
 
             case "ExitThenAbandon":
-                logTrace("ExplorationAbandoned")
+                log("ExplorationAbandoned", color: .explorationAbandonedIS)
 
             case "MissionCompletedFlag":
                 logTrace("FightCompleted")
@@ -281,22 +286,22 @@ extension MAAViewModel {
                 logTrace("FightFailed")
 
             case "StageTraderEnter":
-                logTrace("Trader")
+                log("Trader", color: .traderIS)
 
             case "StageSafeHouseEnter":
-                logTrace("SafeHouse")
+                log("SafeHouse", color: .safehouseIS)
 
             case "StageEncounterEnter":
-                logTrace("Encounter")
+                log("Encounter", color: .eventIS)
 
             case "StageCombatOpsEnter":
-                logTrace("CombatOps")
+                log("CombatOps", color: .combatIS)
 
             case "StageEmergencyOps":
-                logTrace("EmergencyOps")
+                log("EmergencyOps", color: .emergencyIS)
 
             case "StageDreadfulFoe", "StageDreadfulFoe-5Enter":
-                logTrace("DreadfulFoe")
+                log("DreadfulFoe", color: .bossIS)
 
             case "StageTraderInvestSystemFull":
                 logInfo("UpperLimit")
@@ -309,13 +314,13 @@ extension MAAViewModel {
                 logWarn("GameDrop")
 
             case "GamePass":
-                logRare("RoguelikeGamePass")
+                log("RoguelikeGamePass", color: .rareOperator)
 
             case "BattleStartAll":
-                logInfo("MissionStart")
+                log("MissionStart", color: .info, splitMode: .before)
 
             case "StageTraderSpecialShoppingAfterRefresh":
-                logRare("RoguelikeSpecialItemBought")
+                log("RoguelikeSpecialItemBought", color: .rareOperator)
 
             default:
                 break
@@ -366,30 +371,57 @@ extension MAAViewModel {
                 return
             }
 
-            var allDrops = [String]()
-            for item in statistics {
-                guard let name = item["itemName"].string,
-                    let total = item["quantity"].int,
-                    let addition = item["addQuantity"].int
-                else {
-                    continue
-                }
-
-                var drop = "\(name) : \(total)"
-                if addition > 0 {
-                    drop += " (+\(addition))"
-                }
-                allDrops.append(drop)
+            struct DropEntry: Hashable {
+                let name: String
+                let total: Int
+                let add: Int
             }
 
-            if allDrops.count == 0 {
+            var drops = statistics.compactMap { item -> DropEntry? in
+                guard let name = item["itemName"].string,
+                    let total = item["quantity"].int,
+                    let add = item["addQuantity"].int
+                else {
+                    return nil
+                }
+                return DropEntry(name: name == "furni" ? String(localized: "FurnitureDrop") : name, total: total, add: add)
+            }
+
+            // 先按新增数量降序，再按总数量降序（对齐 Windows）
+            drops.sort { a, b in
+                if a.add != b.add { return a.add > b.add }
+                return a.total > b.total
+            }
+
+            var allDrops = drops.map { drop -> String in
+                var line = "\(drop.name) : \(drop.total)"
+                if drop.add > 0 {
+                    line += " (+\(drop.add))"
+                }
+                return line
+            }
+
+            if allDrops.isEmpty {
                 allDrops.append(String(localized: "NoDrop"))
             }
 
+            let stageCode = subTaskDetails["stage"]["stageCode"].string ?? ""
+            var output = "\(stageCode) \(String(localized: "TotalDrop"))\n" + allDrops.joined(separator: "\n")
+            if let curTimes = subTaskDetails["cur_times"].int, curTimes > 0 {
+                output += "\n\(String(localized: "CurTimes")) : \(curTimes)"
+            }
+            if let weekly = subTaskDetails["annihilation_weekly_process"].array, weekly.count == 2 {
+                output += "\n\(String(localized: "AnnihilationMode")) : \(weekly[0].intValue) / \(weekly[1].intValue)"
+            }
+
+            let tooltip = drops
+                .filter { $0.add > 0 }
+                .map { "\($0.name) : \($0.total) (+\($0.add))" }
+                .joined(separator: "\n")
+
             let sanityLeft = self.curSanityBeforeFight - self.sanityCost
-            logTrace(
-                "TotalDrop\n\(allDrops.joined(separator: "\n"))\n\nSanityLeft: \(sanityLeft >= 0 ? String(sanityLeft) : "Error")"
-            )
+            output += "\n" + String(localized: "SanityLeft") + ": \(sanityLeft >= 0 ? String(sanityLeft) : "Error")"
+            writeLog(output, color: .success, toolTip: tooltip, splitMode: .before, updateCardImage: true)
 
         case "EnterFacility":
             guard let facility = subTaskDetails["facility"].string,
@@ -407,7 +439,7 @@ extension MAAViewModel {
                 break
             }
             let tagNames = tags.compactMap(\.string)
-            logTrace("RecruitingResults: \(tagNames.joined(separator: ", "))")
+            log("RecruitingResults: \(tagNames.joined(separator: ", "))", color: .trace, splitMode: .before)
 
         case "RecruitSpecialTag":
             if let special = subTaskDetails["tag"].string {
@@ -425,12 +457,12 @@ extension MAAViewModel {
             guard let level = subTaskDetails["level"].int else {
                 break
             }
+            let tooltip = recruitResultTooltip(details: subTaskDetails)
             if level >= 5 {
                 // TODO: Push Notification
-                // TODO: Bold
-                logRare("\(level) ★ Tags")
+                log("\(level) ★ Tags", color: .rareOperator, weight: .bold, toolTip: tooltip)
             } else {
-                logInfo("\(level) ★ Tags")
+                log("\(level) ★ Tags", color: .info, toolTip: tooltip)
             }
 
         case "RecruitTagsSelect":
@@ -459,7 +491,7 @@ extension MAAViewModel {
             logTrace("StartCombat \(name)")
 
         case "StageInfoError":
-            logError("StageInfoError")
+            log("StageInfoError", color: .error, splitMode: .both, updateCardImage: true)
 
         case "PenguinId":
             if let id = subTaskDetails["id"].string {
@@ -492,7 +524,7 @@ extension MAAViewModel {
             }
 
         case "SSSGamePass":
-            logRare("SSSGamePass")
+            log("SSSGamePass", color: .rareOperator)
 
         case "UnsupportedLevel":
             logError("UnsupportedLevel")
@@ -639,32 +671,143 @@ extension Int {
 
 // MARK: - Convenience Methods
 
+/// 日志卡片拆分模式（对齐 Windows `TaskQueueViewModel.LogCardSplitMode`）
+enum LogCardSplitMode {
+    case none
+    case before
+    case after
+    case both
+}
+
 extension MAAViewModel {
     func logTrace(_ key: String.LocalizationValue, comment: StaticString? = nil) {
-        writeLog(color: .trace, key, comment: comment)
+        writeLog(String(localized: key, comment: comment), color: .trace)
     }
 
     func logInfo(_ key: String.LocalizationValue, comment: StaticString? = nil) {
-        writeLog(color: .info, key, comment: comment)
+        writeLog(String(localized: key, comment: comment), color: .info)
     }
 
     func logWarn(_ key: String.LocalizationValue, comment: StaticString? = nil) {
-        writeLog(color: .warning, key, comment: comment)
+        writeLog(String(localized: key, comment: comment), color: .warning)
     }
 
     func logRare(_ key: String.LocalizationValue, comment: StaticString? = nil) {
-        writeLog(color: .rare, key, comment: comment)
+        writeLog(String(localized: key, comment: comment), color: .rare)
     }
 
     func logError(_ key: String.LocalizationValue, comment: StaticString? = nil) {
-        writeLog(color: .error, key, comment: comment)
+        writeLog(String(localized: key, comment: comment), color: .error)
     }
 
-    private func writeLog(color: MAALog.LogColor, _ key: String.LocalizationValue, comment: StaticString?) {
-        let content = String(localized: key, comment: comment)
-        let entry = MAALog(date: Date(), content: content, color: color)
+    func logSuccess(_ key: String.LocalizationValue, comment: StaticString? = nil) {
+        writeLog(String(localized: key, comment: comment), color: .success)
+    }
+
+    func logMessage(_ key: String.LocalizationValue, comment: StaticString? = nil) {
+        writeLog(String(localized: key, comment: comment), color: .message)
+    }
+
+    func logDownload(_ key: String.LocalizationValue, comment: StaticString? = nil) {
+        writeLog(String(localized: key, comment: comment), color: .download)
+    }
+
+    /// 通用写日志入口，对齐 Windows `AddLog` 的 color/weight/toolTip/splitMode/updateCardImage。
+    private func log(
+        _ key: String.LocalizationValue,
+        color: MAALog.LogColor,
+        weight: MAALog.LogWeight? = nil,
+        toolTip: String? = nil,
+        splitMode: LogCardSplitMode = .none,
+        updateCardImage: Bool = false,
+        comment: StaticString? = nil
+    ) {
+        writeLog(
+            String(localized: key, comment: comment),
+            color: color,
+            weight: weight,
+            toolTip: toolTip,
+            splitMode: splitMode,
+            updateCardImage: updateCardImage)
+    }
+
+    /// 写日志并同步维护卡片列表（对齐 Windows `AddLog` 的卡片逻辑）。
+    private func writeLog(
+        _ content: String,
+        color: MAALog.LogColor,
+        weight: MAALog.LogWeight? = nil,
+        toolTip: String? = nil,
+        showTime: Bool = true,
+        splitMode: LogCardSplitMode = .none,
+        updateCardImage: Bool = false
+    ) {
+        let entry = MAALog(
+            date: Date(),
+            content: content,
+            color: color,
+            weight: weight,
+            toolTip: toolTip,
+            showTime: showTime)
         logs.append(entry)
         fileLogger.write(entry)
+
+        let needsBeforeSplit = splitMode == .before || splitMode == .both
+        let needsAfterSplit = splitMode == .after || splitMode == .both
+
+        if needsBeforeSplit {
+            createNewCard()
+        }
+        if logCards.isEmpty {
+            createNewCard()
+        }
+        if !logCards.isEmpty {
+            let lastIndex = logCards.count - 1
+            logCards[lastIndex].items.append(entry)
+            if updateCardImage {
+                attachThumbnail(toCardAt: lastIndex)
+            }
+        }
+        if needsAfterSplit {
+            createNewCard()
+        }
+    }
+
+    /// 创建新卡片；若当前最后一张为空普通卡片则复用（对齐 Windows `createNewCard`）。
+    private func createNewCard() {
+        if let last = logCards.last, last.items.isEmpty, !last.isDivider {
+            return
+        }
+        logCards.append(LogCardItem())
+    }
+
+    /// 为卡片异步附加截图缩略图（对齐 Windows `AttachThumbnailToCardAsync`）。
+    private func attachThumbnail(toCardAt index: Int) {
+        guard logCards.indices.contains(index) else { return }
+        Task { @MainActor in
+            guard logCards.indices.contains(index) else { return }
+            if let image = try? await screenshot() {
+                logCards[index].thumbnail = image
+            }
+        }
+    }
+
+    /// 构建公招结果的 tooltip（标签 + 可能干员，对齐 Windows `RecruitResultInlines`）。
+    private func recruitResultTooltip(details: JSON) -> String? {
+        guard let results = details["result"].array else {
+            return nil
+        }
+        var lines = [String]()
+        for combo in results {
+            let tags = combo["tags"].array?.compactMap(\.string).joined(separator: "、") ?? ""
+            let opers = combo["opers"].array?.compactMap { $0["name"].string }.joined(separator: "、") ?? ""
+            if !tags.isEmpty {
+                lines.append(tags)
+            }
+            if !opers.isEmpty {
+                lines.append("   " + opers)
+            }
+        }
+        return lines.isEmpty ? nil : lines.joined(separator: "\n")
     }
 
     func taskID(taskDetails: JSON) -> UUID? {

--- a/MeoAsstMac/Core/MaaMessage.swift
+++ b/MeoAsstMac/Core/MaaMessage.swift
@@ -671,14 +671,6 @@ extension Int {
 
 // MARK: - Convenience Methods
 
-/// 日志卡片拆分模式（对齐 Windows `TaskQueueViewModel.LogCardSplitMode`）
-enum LogCardSplitMode {
-    case none
-    case before
-    case after
-    case both
-}
-
 extension MAAViewModel {
     func logTrace(_ key: String.LocalizationValue, comment: StaticString? = nil) {
         writeLog(String(localized: key, comment: comment), color: .trace)
@@ -710,85 +702,6 @@ extension MAAViewModel {
 
     func logDownload(_ key: String.LocalizationValue, comment: StaticString? = nil) {
         writeLog(String(localized: key, comment: comment), color: .download)
-    }
-
-    /// 通用写日志入口，对齐 Windows `AddLog` 的 color/weight/toolTip/splitMode/updateCardImage。
-    private func log(
-        _ key: String.LocalizationValue,
-        color: MAALog.LogColor,
-        weight: MAALog.LogWeight? = nil,
-        toolTip: String? = nil,
-        splitMode: LogCardSplitMode = .none,
-        updateCardImage: Bool = false,
-        comment: StaticString? = nil
-    ) {
-        writeLog(
-            String(localized: key, comment: comment),
-            color: color,
-            weight: weight,
-            toolTip: toolTip,
-            splitMode: splitMode,
-            updateCardImage: updateCardImage)
-    }
-
-    /// 写日志并同步维护卡片列表（对齐 Windows `AddLog` 的卡片逻辑）。
-    private func writeLog(
-        _ content: String,
-        color: MAALog.LogColor,
-        weight: MAALog.LogWeight? = nil,
-        toolTip: String? = nil,
-        showTime: Bool = true,
-        splitMode: LogCardSplitMode = .none,
-        updateCardImage: Bool = false
-    ) {
-        let entry = MAALog(
-            date: Date(),
-            content: content,
-            color: color,
-            weight: weight,
-            toolTip: toolTip,
-            showTime: showTime)
-        logs.append(entry)
-        fileLogger.write(entry)
-
-        let needsBeforeSplit = splitMode == .before || splitMode == .both
-        let needsAfterSplit = splitMode == .after || splitMode == .both
-
-        if needsBeforeSplit {
-            createNewCard()
-        }
-        if logCards.isEmpty {
-            createNewCard()
-        }
-        if !logCards.isEmpty {
-            let lastIndex = logCards.count - 1
-            logCards[lastIndex].items.append(entry)
-            if updateCardImage {
-                attachThumbnail(toCardAt: lastIndex)
-            }
-        }
-        if needsAfterSplit {
-            createNewCard()
-        }
-    }
-
-    /// 创建新卡片；若当前最后一张为空普通卡片则复用（对齐 Windows `createNewCard`）。
-    private func createNewCard() {
-        if let last = logCards.last, last.items.isEmpty, !last.isDivider {
-            return
-        }
-        logCards.append(LogCardItem())
-    }
-
-    /// 为卡片异步附加截图缩略图（对齐 Windows `AttachThumbnailToCardAsync`）。
-    private func attachThumbnail(toCardAt index: Int) {
-        guard logCards.indices.contains(index) else { return }
-        Task { @MainActor in
-            guard logCards.indices.contains(index) else { return }
-            if let image = try? await screenshot() {
-                logCards[index].thumbnail = image
-            }
-        }
     }
 
     /// 构建公招结果的 tooltip（标签 + 可能干员，对齐 Windows `RecruitResultInlines`）。

--- a/MeoAsstMac/Model/MAALog.swift
+++ b/MeoAsstMac/Model/MAALog.swift
@@ -232,3 +232,94 @@ extension MAALog.LogColor {
         }
     }
 }
+
+// MARK: - Log 写入与卡片维护
+
+/// 日志卡片拆分模式（对齐 Windows `TaskQueueViewModel.LogCardSplitMode`）
+enum LogCardSplitMode {
+    case none
+    case before
+    case after
+    case both
+}
+
+extension MAAViewModel {
+    /// 通用写日志入口，对齐 Windows `AddLog` 的 color/weight/toolTip/splitMode/updateCardImage。
+    func log(
+        _ key: String.LocalizationValue,
+        color: MAALog.LogColor,
+        weight: MAALog.LogWeight? = nil,
+        toolTip: String? = nil,
+        splitMode: LogCardSplitMode = .none,
+        updateCardImage: Bool = false,
+        comment: StaticString? = nil
+    ) {
+        writeLog(
+            String(localized: key, comment: comment),
+            color: color,
+            weight: weight,
+            toolTip: toolTip,
+            splitMode: splitMode,
+            updateCardImage: updateCardImage)
+    }
+
+    /// 写日志并同步维护卡片列表（对齐 Windows `AddLog` 的卡片逻辑）。
+    func writeLog(
+        _ content: String,
+        color: MAALog.LogColor,
+        weight: MAALog.LogWeight? = nil,
+        toolTip: String? = nil,
+        showTime: Bool = true,
+        splitMode: LogCardSplitMode = .none,
+        updateCardImage: Bool = false
+    ) {
+        let entry = MAALog(
+            date: Date(),
+            content: content,
+            color: color,
+            weight: weight,
+            toolTip: toolTip,
+            showTime: showTime)
+        logs.append(entry)
+        fileLogger.write(entry)
+
+        let needsBeforeSplit = splitMode == .before || splitMode == .both
+        let needsAfterSplit = splitMode == .after || splitMode == .both
+
+        if needsBeforeSplit {
+            createNewCard()
+        }
+        if logCards.isEmpty {
+            createNewCard()
+        }
+        if !logCards.isEmpty {
+            let lastIndex = logCards.count - 1
+            logCards[lastIndex].items.append(entry)
+            if updateCardImage {
+                attachThumbnail(toCardAt: lastIndex)
+            }
+        }
+        if needsAfterSplit {
+            createNewCard()
+        }
+    }
+
+    /// 创建新卡片；若当前最后一张为空普通卡片则复用（对齐 Windows `createNewCard`）。
+    func createNewCard() {
+        if let last = logCards.last, last.items.isEmpty, !last.isDivider {
+            return
+        }
+        logCards.append(LogCardItem())
+    }
+
+    /// 为卡片异步附加截图缩略图（对齐 Windows `AttachThumbnailToCardAsync`）。
+    func attachThumbnail(toCardAt index: Int) {
+        guard logCards.indices.contains(index) else { return }
+        Task { @MainActor in
+            guard logCards.indices.contains(index) else { return }
+            if let image = try? await screenshot() {
+                logCards[index].thumbnail = image
+            }
+        }
+    }
+}

--- a/MeoAsstMac/Model/MAALog.swift
+++ b/MeoAsstMac/Model/MAALog.swift
@@ -9,12 +9,60 @@ import Foundation
 import SwiftUI
 
 struct MAALog: Identifiable, Hashable {
-    enum LogColor {
+    enum LogColor: Hashable {
+        // MARK: 基础语义色
+
         case trace
         case info
         case rare
         case warning
         case error
+        case success
+        case message
+        case download
+
+        /// 稀有干员 / 5★ 以上 / 肉鸽通关等高价值信息
+        case rareOperator
+
+        // MARK: 公招星级
+
+        case star(Int, potentialFull: Bool)
+
+        // MARK: 集成战略（I.S.）节点色
+
+        case successIS
+        case safehouseIS
+        case traderIS
+        case eventIS
+        case truthIS
+        case combatIS
+        case emergencyIS
+        case bossIS
+        case explorationAbandonedIS
+
+        // MARK: 岁园奇景（JieGarden）节点色
+
+        case omissionsIS
+        case legendIS
+        case oldShopIS
+        case schemeIS
+        case playtimeIS
+        case doubtsIS
+    }
+
+    /// 日志字体粗细（对齐 Windows 的 Regular / Bold）
+    enum LogWeight: Hashable {
+        case regular
+        case bold
+
+        var fontWeight: Font.Weight {
+            switch self {
+            case .regular:
+                return .regular
+            case .bold:
+                return .bold
+            }
+        }
     }
 
     let id = UUID()
@@ -22,6 +70,32 @@ struct MAALog: Identifiable, Hashable {
     let date: Date
     let content: String
     let color: LogColor
+    var weight: LogWeight? = nil
+    var toolTip: String? = nil
+    var showTime: Bool = true
+}
+
+/// 日志卡片（详细模式下的分组单元，对应 Windows LogCardItemViewModel）
+struct LogCardItem: Identifiable {
+    let id = UUID()
+
+    var items: [MAALog] = []
+    /// 是否仅作为分隔标题展示（hc:Divider）
+    var isDivider: Bool = false
+    var header: String?
+    /// 关卡截图缩略图
+    var thumbnail: NSImage?
+
+    var startTime: Date? { items.first?.date }
+    var endTime: Date? { items.last?.date }
+}
+
+extension LogCardItem: Equatable {
+    /// 手动实现 Equatable：thumbnail（NSImage）不可比较，id 每次新建恒不同。
+    /// 相等性只看卡片内容是否变化，用于 onChange/动画判断。
+    static func == (lhs: LogCardItem, rhs: LogCardItem) -> Bool {
+        lhs.items == rhs.items && lhs.isDivider == rhs.isDivider && lhs.header == rhs.header
+    }
 }
 
 extension Date {
@@ -42,19 +116,119 @@ extension Date {
     }
 }
 
+// MARK: - 动态颜色（浅色 / 深色外观）
+
+extension Color {
+    /// 用浅色 / 深色两套十六进制颜色创建随系统外观自适应的颜色。
+    init(light: UInt, dark: UInt) {
+        self.init(NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            return NSColor(hex: isDark ? dark : light)
+        })
+    }
+}
+
+extension NSColor {
+    /// 支持 24 位（RRGGBB）与 32 位（AARRGGBB）两种写法。
+    convenience init(hex: UInt) {
+        let alpha: CGFloat
+        let rgb: UInt
+        if hex > 0xFFFFFF {
+            alpha = CGFloat((hex >> 24) & 0xFF) / 255.0
+            rgb = hex & 0xFFFFFF
+        } else {
+            alpha = 1.0
+            rgb = hex
+        }
+        self.init(
+            calibratedRed: CGFloat((rgb >> 16) & 0xFF) / 255.0,
+            green: CGFloat((rgb >> 8) & 0xFF) / 255.0,
+            blue: CGFloat(rgb & 0xFF) / 255.0,
+            alpha: alpha)
+    }
+}
+
+extension Color {
+    init(hex: UInt) {
+        self.init(NSColor(hex: hex))
+    }
+}
+
 extension MAALog.LogColor {
+    /// 颜色值对齐 Windows 版 `Dark.xaml` / `Light.xaml` 的日志刷子。
     var textColor: Color {
         switch self {
         case .trace:
-            return .primary
+            return Color(light: 0x6E6E6E, dark: 0xA9A9A9)
         case .info:
-            return Color("log.color.info")
-        case .rare:
-            return .orange
+            return Color(light: 0x008080, dark: 0x00C8C8)
+        case .rare, .rareOperator:
+            return Color(light: 0xD2691E, dark: 0xFFA500)
         case .warning:
-            return .purple
+            return Color(light: 0xB8860B, dark: 0xDAA520)
         case .error:
             return .red
+        case .success:
+            return Color(light: 0x228B22, dark: 0x90EE90)
+        case .message:
+            return Color(light: 0x404040, dark: 0xE6E6E6)
+        case .download:
+            return Color(light: 0x8B008B, dark: 0xEE82EE)
+        case .star(let level, let potentialFull):
+            let base = Self.starColor(level)
+            return potentialFull ? base.opacity(0.4) : base
+        // 集成战略：浅色用原始亮色，深色用日志柔和色
+        case .successIS:
+            return Color(light: 0x32CD32, dark: 0x91B091)
+        case .safehouseIS:
+            return Color(light: 0x1E90FF, dark: 0x8DA4BA)
+        case .traderIS:
+            return Color(light: 0x3CB371, dark: 0x93AB9E)
+        case .eventIS:
+            return Color(light: 0x87CEFA, dark: 0xA2B0B9)
+        case .truthIS:
+            return Color(light: 0x8D701C, dark: 0xA39E8D)
+        case .combatIS:
+            return Color(light: 0xFF8C00, dark: 0xBAA387)
+        case .emergencyIS:
+            return Color(light: 0xC71585, dark: 0xAF8BA2)
+        case .bossIS:
+            return Color(light: 0xB22222, dark: 0xAB8E8E)
+        case .explorationAbandonedIS:
+            return Color(light: 0x708090, dark: 0x9EA1A4)
+        // 岁园奇景：浅色用原始亮色，深色用日志柔和色
+        case .omissionsIS:
+            return Color(light: 0x98D8C8, dark: 0x9AB8B0)
+        case .legendIS:
+            return Color(light: 0x00CED1, dark: 0x8DB5B6)
+        case .oldShopIS:
+            return Color(light: 0xFFB347, dark: 0xBAAA91)
+        case .schemeIS:
+            return Color(light: 0x9370DB, dark: 0xA79BB5)
+        case .playtimeIS:
+            return Color(light: 0xFFB6C1, dark: 0xBAABB0)
+        case .doubtsIS:
+            return Color(light: 0xF0E68C, dark: 0xB5B09A)
+        }
+    }
+
+    /// 公招星级色（对齐 Windows Star1-6OperatorLogBrush）
+    private static func starColor(_ level: Int) -> Color {
+        switch level {
+        case 1:
+            return Color(light: 0x808080, dark: 0xE6E6E6)
+        case 2:
+            return Color(light: 0x4F8A10, dark: 0x88BB44)
+        case 3:
+            return Color(light: 0x1E90FF, dark: 0x66CCFF)
+        case 4:
+            return Color(light: 0x8A2BE2, dark: 0xBB88FF)
+        case 5:
+            return Color(light: 0xDAA520, dark: 0xEED694)
+        case 6:
+            return Color(light: 0xFF8C00, dark: 0xFFA500)
+        default:
+            return .primary
         }
     }
 }

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -38,6 +38,12 @@ import SwiftUI
 
     private var messageTask: Task<Void, Never>?
     @Published var logs = [MAALog]()
+    /// 详细日志模式下的卡片列表（对应 Windows LogCardViewModels）
+    @Published var logCards = [LogCardItem]()
+    /// 日志样式：true = 详细（卡片），false = 精简（对应 Windows GuiSettings.UseCardLog）
+    @AppStorage("MAAUseCardLog") var useCardLog = true
+    /// 是否已连接模拟器/客户端（对应 Windows AsstProxy.Connected）
+    @Published var isConnected = false
     @Published var trackTail = false
     let fileLogger: FileLogger
 
@@ -61,6 +67,10 @@ import SwiftUI
         case failure
         case running
         case success
+        /// 空闲（未运行），对齐 Windows TaskItemStatus.Idle
+        case idle
+        /// 跳过（任务被禁用），对齐 Windows TaskItemStatus.Skipped
+        case skipped
     }
 
     @Published var taskStatus: [UUID: TaskStatus] = [:]
@@ -221,6 +231,7 @@ extension MAAViewModel {
         }
 
         logs.removeAll()
+        logCards.removeAll()
         taskIDMap.removeAll()
         taskStatus.removeAll()
 
@@ -472,6 +483,11 @@ extension MAAViewModel {
         }
 
         try await ensureHandle()
+
+        // 对齐 Windows：开始前把启用任务置为空闲，禁用任务置为跳过
+        for task in tasks {
+            taskStatus[task.id] = task.enabled ? .idle : .skipped
+        }
 
         for task in tasks {
             guard task.enabled else { continue }

--- a/MeoAsstMac/Navigation/Sidebar.swift
+++ b/MeoAsstMac/Navigation/Sidebar.swift
@@ -14,6 +14,7 @@ struct Sidebar: View {
     let onUpdate: () async throws -> Void
 
     @Environment(\.defaultMinListRowHeight) var rowHeight
+    @EnvironmentObject private var viewModel: MAAViewModel
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -40,6 +41,18 @@ struct Sidebar: View {
             }
             .buttonStyle(.plain)
             .padding()
+
+            // 连接状态指示（对齐 Windows AsstProxy.Connected）
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(viewModel.isConnected ? Color.green : Color.red)
+                    .frame(width: 8, height: 8)
+                Text(viewModel.isConnected ? "已连接" : "未连接")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 8)
         }
         .sheet(isPresented: $showUpdate) {
             ResourceUpdateView(onUpdate: onUpdate)

--- a/MeoAsstMac/Navigation/Sidebar.swift
+++ b/MeoAsstMac/Navigation/Sidebar.swift
@@ -47,7 +47,7 @@ struct Sidebar: View {
                 Circle()
                     .fill(viewModel.isConnected ? Color.green : Color.red)
                     .frame(width: 8, height: 8)
-                Text(viewModel.isConnected ? "已连接" : "未连接")
+                Text(viewModel.isConnected ? String(localized: "已连接") : String(localized: "未连接"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/MeoAsstMac/Settings/SystemSettingsView.swift
+++ b/MeoAsstMac/Settings/SystemSettingsView.swift
@@ -5,13 +5,13 @@ struct SystemSettingsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Picker("日志样式", selection: $viewModel.useCardLog) {
-                Text("精简").tag(false)
-                Text("详细").tag(true)
+            Picker(String(localized: "日志样式"), selection: $viewModel.useCardLog) {
+                Text(String(localized: "精简")).tag(false)
+                Text(String(localized: "详细")).tag(true)
             }
             .pickerStyle(.segmented)
 
-            Text("详细：以卡片分组展示日志，包含掉落截图缩略图；精简：以表格逐行展示")
+            Text(String(localized: "详细：以卡片分组展示日志，包含掉落截图缩略图；精简：以表格逐行展示"))
                 .font(.caption).foregroundStyle(.secondary)
 
             Divider()

--- a/MeoAsstMac/Settings/SystemSettingsView.swift
+++ b/MeoAsstMac/Settings/SystemSettingsView.swift
@@ -4,7 +4,18 @@ struct SystemSettingsView: View {
     @EnvironmentObject private var viewModel: MAAViewModel
 
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: 12) {
+            Picker("日志样式", selection: $viewModel.useCardLog) {
+                Text("精简").tag(false)
+                Text("详细").tag(true)
+            }
+            .pickerStyle(.segmented)
+
+            Text("详细：以卡片分组展示日志，包含掉落截图缩略图；精简：以表格逐行展示")
+                .font(.caption).foregroundStyle(.secondary)
+
+            Divider()
+
             Toggle(isOn: $viewModel.preventSystemSleeping) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("阻止系统睡眠")

--- a/MeoAsstMac/Views/LogView.swift
+++ b/MeoAsstMac/Views/LogView.swift
@@ -24,13 +24,6 @@ struct LogView: View {
             .animation(.default, value: viewModel.logs)
             .animation(.default, value: viewModel.logCards)
             .toolbar {
-                Picker("日志样式", selection: $viewModel.useCardLog) {
-                    Text("精简").tag(false)
-                    Text("详细").tag(true)
-                }
-                .pickerStyle(.menu)
-                .help("日志样式")
-
                 Toggle(isOn: $viewModel.trackTail) {
                     Label("现在", systemImage: "arrow.down.to.line")
                 }

--- a/MeoAsstMac/Views/LogView.swift
+++ b/MeoAsstMac/Views/LogView.swift
@@ -7,44 +7,180 @@
 
 import SwiftUI
 
+/// 日志视图：支持「精简」（时间+信息表格）与「详细」（卡片分组日志）两种样式，
+/// 对齐 Windows 版 `TaskQueueView` 的 plain-text 与 card-log 两种渲染。
 struct LogView: View {
     @EnvironmentObject private var viewModel: MAAViewModel
 
     var body: some View {
         ScrollViewReader { proxy in
-            Table(viewModel.logs) {
-                TableColumn("时间", value: \.date.maaGuiLogFormat)
-                    .width(min: 100, ideal: 125, max: 150)
-                TableColumn("信息") { log in
-                    Text(log.content)
-                        .textSelection(.enabled)
-                        .foregroundStyle(log.color.textColor)
-                        .lineLimit(nil)
+            Group {
+                if viewModel.useCardLog {
+                    CardLogView(proxy: proxy)
+                } else {
+                    ConciseLogView(proxy: proxy)
                 }
-                .width(min: 100, ideal: 300)
             }
             .animation(.default, value: viewModel.logs)
+            .animation(.default, value: viewModel.logCards)
             .toolbar {
+                Picker("日志样式", selection: $viewModel.useCardLog) {
+                    Text("精简").tag(false)
+                    Text("详细").tag(true)
+                }
+                .pickerStyle(.menu)
+                .help("日志样式")
+
                 Toggle(isOn: $viewModel.trackTail) {
                     Label("现在", systemImage: "arrow.down.to.line")
                 }
                 .help("自动滚动到底部")
             }
-            .onChange(of: viewModel.logs) {
-                if viewModel.trackTail {
-                    withAnimation {
-                        proxy.scrollTo(viewModel.logs.last?.id ?? UUID())
-                    }
-                }
+        }
+    }
+}
+
+// MARK: - 精简模式
+
+private struct ConciseLogView: View {
+    @EnvironmentObject private var viewModel: MAAViewModel
+    let proxy: ScrollViewProxy
+
+    var body: some View {
+        Table(viewModel.logs) {
+            TableColumn("时间", value: \.date.maaGuiLogFormat)
+                .width(min: 100, ideal: 125, max: 150)
+            TableColumn("信息") { log in
+                Text(log.content)
+                    .textSelection(.enabled)
+                    .foregroundStyle(log.color.textColor)
+                    .fontWeight(log.weight?.fontWeight ?? .regular)
+                    .help(log.toolTip ?? "")
+                    .lineLimit(nil)
             }
-            .onChange(of: viewModel.trackTail) {
-                if $1 {
-                    withAnimation {
-                        proxy.scrollTo(viewModel.logs.last?.id ?? UUID())
-                    }
+            .width(min: 100, ideal: 300)
+        }
+        .onChange(of: viewModel.logs) {
+            if viewModel.trackTail {
+                withAnimation {
+                    proxy.scrollTo(viewModel.logs.last?.id ?? UUID())
                 }
             }
         }
+    }
+}
+
+// MARK: - 详细模式（卡片日志）
+
+private struct CardLogView: View {
+    @EnvironmentObject private var viewModel: MAAViewModel
+    let proxy: ScrollViewProxy
+
+    private var visibleCards: [LogCardItem] {
+        viewModel.logCards.filter { !$0.items.isEmpty || $0.isDivider }
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 8) {
+                ForEach(visibleCards) { card in
+                    if card.isDivider {
+                        LogCardDivider(header: card.header)
+                            .id(card.id)
+                    } else {
+                        LogCardRow(card: card)
+                            .id(card.id)
+                    }
+                }
+            }
+            .padding(.vertical, 8)
+        }
+        .onChange(of: viewModel.logCards) {
+            if viewModel.trackTail, let last = visibleCards.last {
+                withAnimation {
+                    proxy.scrollTo(last.id)
+                }
+            }
+        }
+        .onChange(of: viewModel.trackTail) {
+            if $1, let last = visibleCards.last {
+                withAnimation {
+                    proxy.scrollTo(last.id)
+                }
+            }
+        }
+    }
+}
+
+/// 一张日志卡片：左侧时间轴（起止时间 + 可选缩略图），右侧分组日志。
+private struct LogCardRow: View {
+    let card: LogCardItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            // 左侧时间轴列
+            VStack(alignment: .leading, spacing: 4) {
+                if let start = card.startTime {
+                    Text(start.maaGuiLogFormat)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let thumbnail = card.thumbnail {
+                    Image(nsImage: thumbnail)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: 120, maxHeight: 90)
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                        .shadow(radius: 1)
+                        .help("截图")
+                }
+
+                if let end = card.endTime, (end != card.startTime || card.items.count > 1) {
+                    Text(end.maaGuiLogFormat)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 110, alignment: .leading)
+
+            // 右侧日志内容列
+            VStack(alignment: .leading, spacing: 3) {
+                ForEach(card.items) { log in
+                    Text(log.content)
+                        .fontWeight(log.weight?.fontWeight ?? .regular)
+                        .foregroundStyle(log.color.textColor)
+                        .textSelection(.enabled)
+                        .help(log.toolTip ?? "")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color(nsColor: .quaternarySystemFill))
+        )
+    }
+}
+
+/// 卡片之间的分隔标题（对应 Windows hc:Divider）。
+private struct LogCardDivider: View {
+    let header: String?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Rectangle().fill(.quaternary).frame(height: 1)
+            if let header {
+                Text(header)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Rectangle().fill(.quaternary).frame(height: 1)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
     }
 }
 

--- a/MeoAsstMac/Views/LogView.swift
+++ b/MeoAsstMac/Views/LogView.swift
@@ -7,6 +7,18 @@
 
 import SwiftUI
 
+extension View {
+    /// 仅当 tooltip 非空时才安装 `.help`，避免为 nil 生成空提示视图。
+    @ViewBuilder
+    func helpIfNonEmpty(_ toolTip: String?) -> some View {
+        if let toolTip, !toolTip.isEmpty {
+            self.help(toolTip)
+        } else {
+            self
+        }
+    }
+}
+
 /// 日志视图：支持「精简」（时间+信息表格）与「详细」（卡片分组日志）两种样式，
 /// 对齐 Windows 版 `TaskQueueView` 的 plain-text 与 card-log 两种渲染。
 struct LogView: View {
@@ -48,7 +60,7 @@ private struct ConciseLogView: View {
                     .textSelection(.enabled)
                     .foregroundStyle(log.color.textColor)
                     .fontWeight(log.weight?.fontWeight ?? .regular)
-                    .help(log.toolTip ?? "")
+                    .helpIfNonEmpty(log.toolTip)
                     .lineLimit(nil)
             }
             .width(min: 100, ideal: 300)
@@ -57,6 +69,13 @@ private struct ConciseLogView: View {
             if viewModel.trackTail {
                 withAnimation {
                     proxy.scrollTo(viewModel.logs.last?.id ?? UUID())
+                }
+            }
+        }
+        .onChange(of: viewModel.trackTail) {
+            if $1, let last = viewModel.logs.last {
+                withAnimation {
+                    proxy.scrollTo(last.id)
                 }
             }
         }
@@ -144,7 +163,7 @@ private struct LogCardRow: View {
                         .fontWeight(log.weight?.fontWeight ?? .regular)
                         .foregroundStyle(log.color.textColor)
                         .textSelection(.enabled)
-                        .help(log.toolTip ?? "")
+                        .helpIfNonEmpty(log.toolTip)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }

--- a/MeoAsstMac/Views/TaskCell.swift
+++ b/MeoAsstMac/Views/TaskCell.swift
@@ -18,13 +18,13 @@ struct TaskCell<Config: MAATaskConfiguration>: View {
     private var statusColor: Color? {
         switch viewModel.taskStatus[id] {
         case .running:
-            Color(hex: 0x20326CF3)
+            return Color(hex: 0x20326CF3)
         case .success:
-            Color(hex: 0x2090EE90)
+            return Color(hex: 0x2090EE90)
         case .failure:
-            Color(hex: 0x20FF4444)
+            return Color(hex: 0x20FF4444)
         default:
-            nil
+            return nil
         }
     }
 

--- a/MeoAsstMac/Views/TaskCell.swift
+++ b/MeoAsstMac/Views/TaskCell.swift
@@ -12,6 +12,26 @@ struct TaskCell<Config: MAATaskConfiguration>: View {
     let config: Config
 
     @Binding var enabled: Bool
+    @EnvironmentObject private var viewModel: MAAViewModel
+
+    /// 状态背景色（对齐 Windows Dark.xaml 的 12.5% 透明度刷子）
+    private var statusColor: Color? {
+        switch viewModel.taskStatus[id] {
+        case .running:
+            Color(hex: 0x20326CF3)
+        case .success:
+            Color(hex: 0x2090EE90)
+        case .failure:
+            Color(hex: 0x20FF4444)
+        default:
+            nil
+        }
+    }
+
+    /// 禁用的任务：整行半透明（对齐 Windows Skipped）
+    private var isSkipped: Bool {
+        viewModel.taskStatus[id] == .skipped
+    }
 
     var body: some View {
         HStack {
@@ -34,6 +54,11 @@ struct TaskCell<Config: MAATaskConfiguration>: View {
             TaskIndicator(id: id)
         }
         .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(statusColor ?? Color.clear)
+        )
+        .opacity(isSkipped ? 0.5 : 1)
         .contextMenu {
             TaskButtons()
         }
@@ -54,7 +79,7 @@ private struct TaskIndicator: View {
             ProgressView().controlSize(.small)
         case .success:
             Image(systemName: "checkmark.circle").foregroundStyle(.green)
-        case .none:
+        case .idle, .skipped, .none:
             EmptyView()
         }
     }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -5070,6 +5070,22 @@
           }
         }
       }
+    },
+    "截图" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截图"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Screenshot"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4894,6 +4894,182 @@
           }
         }
       }
+    },
+    "TotalDrop" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "掉落"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drops"
+          }
+        }
+      }
+    },
+    "CurTimes" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前次数"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Current times"
+          }
+        }
+      }
+    },
+    "AnnihilationMode" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "周剿灭"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weekly Annihilation"
+          }
+        }
+      }
+    },
+    "FurnitureDrop" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "家具"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Furniture"
+          }
+        }
+      }
+    },
+    "SanityLeft" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剩余理智"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sanity left"
+          }
+        }
+      }
+    },
+    "日志样式" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日志样式"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Log Style"
+          }
+        }
+      }
+    },
+    "精简" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "精简"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Concise"
+          }
+        }
+      }
+    },
+    "详细" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "详细"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detailed"
+          }
+        }
+      }
+    },
+    "已连接" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已连接"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connected"
+          }
+        }
+      }
+    },
+    "未连接" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未连接"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnected"
+          }
+        }
+      }
+    },
+    "详细：以卡片分组展示日志，包含掉落截图缩略图；精简：以表格逐行展示" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "详细：以卡片分组展示日志，包含掉落截图缩略图；精简：以表格逐行展示"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detailed: grouped card view with stage drop thumbnails; Concise: plain table view"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"


### PR DESCRIPTION
Closes #108

关联 issue：[#108](https://github.com/MaaAssistantArknights/MaaMacGui/issues/108)

### 改动

macOS 版日志与任务状态显示对齐 Windows 版（MaaWpfGui），共 8 个文件：

1. **日志色板**（`MAALog.swift`）：`LogColor` 从 5 色扩至 30+ 语义色（基础 / 公招星级 / 肉鸽 IS 节点 / 界园节点），颜色值对齐 Windows `Dark.xaml`/`Light.xaml`，新增 `Color(light:dark:)` 支持深浅色外观。
2. **日志渲染**（`LogView.swift`）：新增「精简 / 详细」两档（默认详细，对应 `GuiSettings.UseCardLog`）。
   - 详细模式：卡片日志（`LogCardItem`），左侧时间轴 + 关卡截图缩略图 + 分组，日志项支持加粗与 tooltip 悬停；`writeLog` 按 `LogCardSplitMode`（before/after/both）拆分卡片，对齐 Windows 的拆分点（任务开始/停止、进设施、掉落结算、公招结果等）。
   - 精简模式：保留原表格，行内支持加粗与 tooltip。
3. **掉落展示**（`MaaMessage.swift`）：`StageDrops` 按新增数降序、总数降序排序，`关卡 总掉落` 头 + `物品 : 总数 (+新增)` 逐行 + 当前次数/周剿灭/剩余理智，以成功色卡片展示并异步附加截图缩略图与 tooltip。
4. **任务状态**（`TaskCell.swift`）：`TaskStatus` 5 态（idle/running/success/failure/skipped），开始任务时启用任务置 idle、禁用任务置 skipped；行彩色背景（运行蓝 `#20326CF3` / 完成绿 `#2090EE90` / 失败红 `#20FF4444` / 跳过半透明）。
5. **连接状态**（`Sidebar.swift`）：`processConnectionInfo` 的 `"Connected"` 从空操作改为更新 `isConnected`，侧边栏底部绿/红圆点指示。
6. **设置**（`SystemSettingsView.swift`）：新增「日志样式 精简/详细」开关。

### 验证

- 本地以官方 dev-v2 为基础构建 `MAA.xcarchive` 成功，安装后启动无崩溃。

### 备注

`LogCardSplitMode` 目前定义于 `MaaMessage.swift`，如需要可挪到更合适的公共位置。

## Summary by Sourcery

使 macOS 日志记录和任务状态展示与 Windows 客户端保持一致，同时添加可配置的详细日志和连接反馈。

New Features:
- 添加可切换的精简与详细卡片式日志视图，包含语义化样式、工具提示、强调、高亮分组以及可选截图。
- 在侧边栏中显示实时连接状态。
- 为空闲、运行中、成功、失败和已跳过任务添加可视化任务状态。

Bug Fixes:
- 根据连接、重新连接、断开连接以及连接错误事件正确更新连接状态。

Enhancements:
- 改进掉落结果日志，提供排序和格式化的条目总数、运行统计、校验信息、工具提示以及高亮的卡片式展示。
- 使 macOS 日志颜色、卡片边界和任务状态展示与 Windows 客户端保持一致。
- 统一日志创建逻辑，同时保持平铺日志与分组卡片日志的同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align macOS logging and task-status presentation with the Windows client while adding configurable detailed logs and connection feedback.

New Features:
- Add switchable concise and detailed card-based log views with semantic styling, tooltips, emphasis, grouping, and optional screenshots.
- Show live connection status in the sidebar.
- Add visual task states for idle, running, successful, failed, and skipped tasks.

Bug Fixes:
- Correctly update the connection state in response to connection, reconnection, disconnection, and connection-error events.

Enhancements:
- Improve drop-result logs with sorted, formatted item totals, run statistics, sanity information, tooltips, and highlighted card presentation.
- Align macOS log colors, card boundaries, and task-state presentation with the Windows client.
- Centralize log creation while keeping flat logs and grouped card logs synchronized.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使 macOS 日志记录和任务状态展示与 Windows 客户端保持一致，同时添加可配置的详细日志和连接反馈。

New Features:
- 添加可切换的精简与详细卡片式日志视图，包含语义化样式、工具提示、强调、高亮分组以及可选截图。
- 在侧边栏中显示实时连接状态。
- 为空闲、运行中、成功、失败和已跳过任务添加可视化任务状态。

Bug Fixes:
- 根据连接、重新连接、断开连接以及连接错误事件正确更新连接状态。

Enhancements:
- 改进掉落结果日志，提供排序和格式化的条目总数、运行统计、校验信息、工具提示以及高亮的卡片式展示。
- 使 macOS 日志颜色、卡片边界和任务状态展示与 Windows 客户端保持一致。
- 统一日志创建逻辑，同时保持平铺日志与分组卡片日志的同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align macOS logging and task-status presentation with the Windows client while adding configurable detailed logs and connection feedback.

New Features:
- Add switchable concise and detailed card-based log views with semantic styling, tooltips, emphasis, grouping, and optional screenshots.
- Show live connection status in the sidebar.
- Add visual task states for idle, running, successful, failed, and skipped tasks.

Bug Fixes:
- Correctly update the connection state in response to connection, reconnection, disconnection, and connection-error events.

Enhancements:
- Improve drop-result logs with sorted, formatted item totals, run statistics, sanity information, tooltips, and highlighted card presentation.
- Align macOS log colors, card boundaries, and task-state presentation with the Windows client.
- Centralize log creation while keeping flat logs and grouped card logs synchronized.

</details>

</details>

新功能：
- 在现有简洁表格日志视图旁新增可切换的卡片式详细日志视图，包括对工具提示、加粗条目和可选截图的支持。
- 引入更丰富、更具语义的日志颜色、权重和卡片拆分行为，包括用于类 Rogue 游戏事件和干员招募相关事件的专用颜色。
- 在侧边栏显示连接状态指示器，用于反映来自后端消息的实时连接状态更新。

缺陷修复：
- 更新连接处理逻辑，以便在解析和重连相关事件发生时正确切换内部连接标志位。

改进：
- 优化掉落结果日志，将物品按关卡、理智值和剿灭战细节进行排序和格式化，并以高亮条目形式展示，支持可选缩略图和工具提示。
- 扩展任务状态跟踪，加入空闲和已跳过状态，并在任务列表中通过行背景和透明度直观展示运行中/成功/失败/已跳过状态。
- 通过统一的 API 集中处理日志写入，同时维护平铺日志列表和分组日志卡片，包括处理卡片边界及截图附件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使 macOS 日志记录和任务状态展示与 Windows 客户端保持一致，同时添加可配置的详细日志和连接反馈。

New Features:
- 添加可切换的精简与详细卡片式日志视图，包含语义化样式、工具提示、强调、高亮分组以及可选截图。
- 在侧边栏中显示实时连接状态。
- 为空闲、运行中、成功、失败和已跳过任务添加可视化任务状态。

Bug Fixes:
- 根据连接、重新连接、断开连接以及连接错误事件正确更新连接状态。

Enhancements:
- 改进掉落结果日志，提供排序和格式化的条目总数、运行统计、校验信息、工具提示以及高亮的卡片式展示。
- 使 macOS 日志颜色、卡片边界和任务状态展示与 Windows 客户端保持一致。
- 统一日志创建逻辑，同时保持平铺日志与分组卡片日志的同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align macOS logging and task-status presentation with the Windows client while adding configurable detailed logs and connection feedback.

New Features:
- Add switchable concise and detailed card-based log views with semantic styling, tooltips, emphasis, grouping, and optional screenshots.
- Show live connection status in the sidebar.
- Add visual task states for idle, running, successful, failed, and skipped tasks.

Bug Fixes:
- Correctly update the connection state in response to connection, reconnection, disconnection, and connection-error events.

Enhancements:
- Improve drop-result logs with sorted, formatted item totals, run statistics, sanity information, tooltips, and highlighted card presentation.
- Align macOS log colors, card boundaries, and task-state presentation with the Windows client.
- Centralize log creation while keeping flat logs and grouped card logs synchronized.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使 macOS 日志记录和任务状态展示与 Windows 客户端保持一致，同时添加可配置的详细日志和连接反馈。

New Features:
- 添加可切换的精简与详细卡片式日志视图，包含语义化样式、工具提示、强调、高亮分组以及可选截图。
- 在侧边栏中显示实时连接状态。
- 为空闲、运行中、成功、失败和已跳过任务添加可视化任务状态。

Bug Fixes:
- 根据连接、重新连接、断开连接以及连接错误事件正确更新连接状态。

Enhancements:
- 改进掉落结果日志，提供排序和格式化的条目总数、运行统计、校验信息、工具提示以及高亮的卡片式展示。
- 使 macOS 日志颜色、卡片边界和任务状态展示与 Windows 客户端保持一致。
- 统一日志创建逻辑，同时保持平铺日志与分组卡片日志的同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align macOS logging and task-status presentation with the Windows client while adding configurable detailed logs and connection feedback.

New Features:
- Add switchable concise and detailed card-based log views with semantic styling, tooltips, emphasis, grouping, and optional screenshots.
- Show live connection status in the sidebar.
- Add visual task states for idle, running, successful, failed, and skipped tasks.

Bug Fixes:
- Correctly update the connection state in response to connection, reconnection, disconnection, and connection-error events.

Enhancements:
- Improve drop-result logs with sorted, formatted item totals, run statistics, sanity information, tooltips, and highlighted card presentation.
- Align macOS log colors, card boundaries, and task-state presentation with the Windows client.
- Centralize log creation while keeping flat logs and grouped card logs synchronized.

</details>

</details>

</details>

新功能：
- 添加卡片式的详细日志视图（带缩略图和工具提示），与现有的简洁表格日志视图并存，可通过新的日志样式设置进行切换。
- 引入更丰富、更语义化的日志颜色和权重，包括类 RogueLike 的节点类型、干员星级以及成功/状态变体。
- 在侧边栏中根据实时连接事件显示连接状态指示器。

改进：
- 优化掉落结果日志：对掉落进行排序和格式化，包含关卡和理智信息，并附加类似 Windows 实现的缩略图和工具提示。
- 扩展任务状态处理，增加空闲（idle）和已跳过（skipped）状态，并通过行背景颜色和不透明度来体现运行中、成功、失败和已跳过的任务。
- 通过统一的 API 集中处理日志写入，同时维护平铺日志列表和分组日志卡片，包括卡片拆分和截图附件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使 macOS 日志记录和任务状态展示与 Windows 客户端保持一致，同时添加可配置的详细日志和连接反馈。

New Features:
- 添加可切换的精简与详细卡片式日志视图，包含语义化样式、工具提示、强调、高亮分组以及可选截图。
- 在侧边栏中显示实时连接状态。
- 为空闲、运行中、成功、失败和已跳过任务添加可视化任务状态。

Bug Fixes:
- 根据连接、重新连接、断开连接以及连接错误事件正确更新连接状态。

Enhancements:
- 改进掉落结果日志，提供排序和格式化的条目总数、运行统计、校验信息、工具提示以及高亮的卡片式展示。
- 使 macOS 日志颜色、卡片边界和任务状态展示与 Windows 客户端保持一致。
- 统一日志创建逻辑，同时保持平铺日志与分组卡片日志的同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align macOS logging and task-status presentation with the Windows client while adding configurable detailed logs and connection feedback.

New Features:
- Add switchable concise and detailed card-based log views with semantic styling, tooltips, emphasis, grouping, and optional screenshots.
- Show live connection status in the sidebar.
- Add visual task states for idle, running, successful, failed, and skipped tasks.

Bug Fixes:
- Correctly update the connection state in response to connection, reconnection, disconnection, and connection-error events.

Enhancements:
- Improve drop-result logs with sorted, formatted item totals, run statistics, sanity information, tooltips, and highlighted card presentation.
- Align macOS log colors, card boundaries, and task-state presentation with the Windows client.
- Centralize log creation while keeping flat logs and grouped card logs synchronized.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使 macOS 日志记录和任务状态展示与 Windows 客户端保持一致，同时添加可配置的详细日志和连接反馈。

New Features:
- 添加可切换的精简与详细卡片式日志视图，包含语义化样式、工具提示、强调、高亮分组以及可选截图。
- 在侧边栏中显示实时连接状态。
- 为空闲、运行中、成功、失败和已跳过任务添加可视化任务状态。

Bug Fixes:
- 根据连接、重新连接、断开连接以及连接错误事件正确更新连接状态。

Enhancements:
- 改进掉落结果日志，提供排序和格式化的条目总数、运行统计、校验信息、工具提示以及高亮的卡片式展示。
- 使 macOS 日志颜色、卡片边界和任务状态展示与 Windows 客户端保持一致。
- 统一日志创建逻辑，同时保持平铺日志与分组卡片日志的同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align macOS logging and task-status presentation with the Windows client while adding configurable detailed logs and connection feedback.

New Features:
- Add switchable concise and detailed card-based log views with semantic styling, tooltips, emphasis, grouping, and optional screenshots.
- Show live connection status in the sidebar.
- Add visual task states for idle, running, successful, failed, and skipped tasks.

Bug Fixes:
- Correctly update the connection state in response to connection, reconnection, disconnection, and connection-error events.

Enhancements:
- Improve drop-result logs with sorted, formatted item totals, run statistics, sanity information, tooltips, and highlighted card presentation.
- Align macOS log colors, card boundaries, and task-state presentation with the Windows client.
- Centralize log creation while keeping flat logs and grouped card logs synchronized.

</details>

</details>

新功能：
- 在现有简洁表格日志视图旁新增可切换的卡片式详细日志视图，包括对工具提示、加粗条目和可选截图的支持。
- 引入更丰富、更具语义的日志颜色、权重和卡片拆分行为，包括用于类 Rogue 游戏事件和干员招募相关事件的专用颜色。
- 在侧边栏显示连接状态指示器，用于反映来自后端消息的实时连接状态更新。

缺陷修复：
- 更新连接处理逻辑，以便在解析和重连相关事件发生时正确切换内部连接标志位。

改进：
- 优化掉落结果日志，将物品按关卡、理智值和剿灭战细节进行排序和格式化，并以高亮条目形式展示，支持可选缩略图和工具提示。
- 扩展任务状态跟踪，加入空闲和已跳过状态，并在任务列表中通过行背景和透明度直观展示运行中/成功/失败/已跳过状态。
- 通过统一的 API 集中处理日志写入，同时维护平铺日志列表和分组日志卡片，包括处理卡片边界及截图附件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使 macOS 日志记录和任务状态展示与 Windows 客户端保持一致，同时添加可配置的详细日志和连接反馈。

New Features:
- 添加可切换的精简与详细卡片式日志视图，包含语义化样式、工具提示、强调、高亮分组以及可选截图。
- 在侧边栏中显示实时连接状态。
- 为空闲、运行中、成功、失败和已跳过任务添加可视化任务状态。

Bug Fixes:
- 根据连接、重新连接、断开连接以及连接错误事件正确更新连接状态。

Enhancements:
- 改进掉落结果日志，提供排序和格式化的条目总数、运行统计、校验信息、工具提示以及高亮的卡片式展示。
- 使 macOS 日志颜色、卡片边界和任务状态展示与 Windows 客户端保持一致。
- 统一日志创建逻辑，同时保持平铺日志与分组卡片日志的同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align macOS logging and task-status presentation with the Windows client while adding configurable detailed logs and connection feedback.

New Features:
- Add switchable concise and detailed card-based log views with semantic styling, tooltips, emphasis, grouping, and optional screenshots.
- Show live connection status in the sidebar.
- Add visual task states for idle, running, successful, failed, and skipped tasks.

Bug Fixes:
- Correctly update the connection state in response to connection, reconnection, disconnection, and connection-error events.

Enhancements:
- Improve drop-result logs with sorted, formatted item totals, run statistics, sanity information, tooltips, and highlighted card presentation.
- Align macOS log colors, card boundaries, and task-state presentation with the Windows client.
- Centralize log creation while keeping flat logs and grouped card logs synchronized.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使 macOS 日志记录和任务状态展示与 Windows 客户端保持一致，同时添加可配置的详细日志和连接反馈。

New Features:
- 添加可切换的精简与详细卡片式日志视图，包含语义化样式、工具提示、强调、高亮分组以及可选截图。
- 在侧边栏中显示实时连接状态。
- 为空闲、运行中、成功、失败和已跳过任务添加可视化任务状态。

Bug Fixes:
- 根据连接、重新连接、断开连接以及连接错误事件正确更新连接状态。

Enhancements:
- 改进掉落结果日志，提供排序和格式化的条目总数、运行统计、校验信息、工具提示以及高亮的卡片式展示。
- 使 macOS 日志颜色、卡片边界和任务状态展示与 Windows 客户端保持一致。
- 统一日志创建逻辑，同时保持平铺日志与分组卡片日志的同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align macOS logging and task-status presentation with the Windows client while adding configurable detailed logs and connection feedback.

New Features:
- Add switchable concise and detailed card-based log views with semantic styling, tooltips, emphasis, grouping, and optional screenshots.
- Show live connection status in the sidebar.
- Add visual task states for idle, running, successful, failed, and skipped tasks.

Bug Fixes:
- Correctly update the connection state in response to connection, reconnection, disconnection, and connection-error events.

Enhancements:
- Improve drop-result logs with sorted, formatted item totals, run statistics, sanity information, tooltips, and highlighted card presentation.
- Align macOS log colors, card boundaries, and task-state presentation with the Windows client.
- Centralize log creation while keeping flat logs and grouped card logs synchronized.

</details>

</details>

</details>

</details>

