### PR TITLE
fix: 触控模式等实例选项在已有实例上重新应用，无需重启生效

### DIFF
--- a/MeoAsstMac/Core/Maa.swift
+++ b/MeoAsstMac/Core/Maa.swift
@@ -77,6 +77,11 @@ actor MAAHandle {
         let selfPtr = Unmanaged.passUnretained(self).toOpaque()
         handle = AsstCreateEx(handleAsst, selfPtr)
 
+        try apply(options: options)
+    }
+
+    /// 应用实例选项（触控模式、AdbLite 等）。可在实例创建后随时调用，核心在下次连接时生效。
+    func apply(options: MAAInstanceOptions) throws {
         for (key, value) in options {
             let success = AsstSetInstanceOption(handle, key.rawValue, value)
             guard success.isTrue else {

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -214,6 +214,9 @@ extension MAAViewModel {
                     self?.processMessage(message)
                 }
             }
+        } else {
+            // 实例已存在时重新应用选项（如触控模式），使设置变更在下次连接即生效，无需重启应用。
+            try await handle?.apply(options: instanceOptions)
         }
 
         guard await handle?.running == false else {


### PR DESCRIPTION
## 改动内容

在每次 `ensureHandle` 时对已存在的 `MAAHandle` 重新应用实例选项（触控模式、adb-lite 等），使「设置 → 连接」中切换触控模式后，下次连接即生效，无需重启应用。

Closes #109

## 为什么改

`MAAHandle.init(options:)` 只在创建实例时把 `instanceOptions`（包含 `.TouchMode`）应用到核心一次。实例之后在整个应用会话中一直存在、从不重建，因此触控模式切换静默无效，直到完全退出应用。

这是一个实际的可用性陷阱：在 Android 15/16 设备/模拟器上，`minitouch` 会因打开 `/dev/input/event*` 被拒绝（`Permission denied`）而失败，标准解法是切换到 `maatouch`——但这次切换看起来「不起作用」，因为它从未真正被应用。

## 怎么改

- `Maa.swift`：把 `MAAHandle.init` 中的 `AsstSetInstanceOption` 循环抽成 `MAAHandle.apply(options:)`。
- `MAAViewModel.swift`：在 `ensureHandle` 中，当实例已存在时，先 `try await handle?.apply(options: instanceOptions)` 再连接。

核心侧该做法是安全的：`Assistant::set_instance_option` / `Controller::set_touch_mode` 只更新成员（`m_controller_type`），下次 `connect` 创建控制器时才会读取。

## 测试

- 使用 `xcodebuild -scheme MAA -configuration Debug -destination 'platform=macOS' build` 构建 → **BUILD SUCCEEDED**。
- 应用修复后，在 `minitouch`/`maatouch`/`adb` 之间切换触控模式并重连，`asst.log` 会出现新的 `set_instance_option | key 2 ...`，且以新选择的控制器类型连接。
