### PR TITLE
feat: 黑流树海肉鸽 GUI 支持（Theme.BlackFlow / 襁褓动物模式）

### DIFF
--- a/MeoAsstMac/Configuration Views/RoguelikeSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/RoguelikeSettingsView.swift
@@ -124,7 +124,7 @@ struct RoguelikeSettingsView: View {
             if config.theme != .Phantom {
                 Toggle("在第五层BOSS前暂停", isOn: $config.stop_at_final_boss)
             }
-            if config.mode == .investment {
+            if config.mode == .investment, config.theme != .BlackFlow {
                 Toggle("投资后进二层", isOn: $config.investment_with_more_score)
             }
             if config.mode == .collectible {
@@ -161,6 +161,14 @@ struct RoguelikeSettingsView: View {
 
         if config.theme == .Sarkaz, config.mode == .collectible {
             Toggle("凹2构想开局", isOn: $config.start_with_two_ideas)
+        }
+
+        if config.theme == .BlackFlow, config.mode == .blackFlowBabyAnimal {
+            Picker("目标襁褓动物", selection: $config.blackflow_cultivation_target) {
+                ForEach(RoguelikeConfiguration.BlackFlowCultivationTarget.allCases, id: \.self) {
+                    Text($0.description).tag($0)
+                }
+            }
         }
 
         if config.mode == .squad {
@@ -205,6 +213,23 @@ extension RoguelikeConfiguration.Mode {
             String(localized: "刷月度小队，到达第五层后直接退出")
         case .exploration:
             String(localized: "刷深入调查，尽可能稳定地打更多层数")
+        case .blackFlowBabyAnimal:
+            String(localized: "刷襁褓动物，刷取指定品种后重开")
+        }
+    }
+}
+
+extension RoguelikeConfiguration.BlackFlowCultivationTarget {
+    var description: String {
+        switch self {
+        case .cat:
+            String(localized: "襁褓中的猫")
+        case .featheredSerpent:
+            String(localized: "襁褓羽蛇")
+        case .dog:
+            String(localized: "襁褓中的狗")
+        case .cerberus:
+            String(localized: "襁褓三头犬")
         }
     }
 }
@@ -222,6 +247,8 @@ extension RoguelikeConfiguration.Theme: CustomStringConvertible {
             return String(localized: "萨卡兹的无终奇语")
         case .JieGarden:
             return String(localized: "岁的界园志异")
+        case .BlackFlow:
+            return String(localized: "黑流树海")
         }
     }
 
@@ -236,6 +263,8 @@ extension RoguelikeConfiguration.Theme: CustomStringConvertible {
         case .Sarkaz:
             return RoguelikeConfiguration.Difficulty.upto(maximum: 18)
         case .JieGarden:
+            return RoguelikeConfiguration.Difficulty.upto(maximum: 15)
+        case .BlackFlow:
             return RoguelikeConfiguration.Difficulty.upto(maximum: 15)
         }
     }
@@ -279,12 +308,19 @@ extension RoguelikeConfiguration.Theme: CustomStringConvertible {
                 "花团锦簇分队", "棋行险着分队", "岁影回音分队",
                 "知学分队", "商贾分队",
             ]
+        case .BlackFlow:
+            [
+                "特勤分队", "矛头分队", "高台突破分队", "地面突破分队",
+                "本源研修分队", "文明开化分队", "开拓者分队", "多边贸易分队", "地质调查分队",
+                "指挥分队", "后勤分队",
+                "突击战术分队", "堡垒战术分队", "远程战术分队", "破坏战术分队",
+            ]
         }
     }
 
     var roles: [String] {
         switch self {
-        case .JieGarden:
+        case .JieGarden, .BlackFlow:
             ["先手必胜", "稳扎稳打", "取长补短", "灵活部署", "坚不可摧", "随心所欲"]
         default:
             ["先手必胜", "稳扎稳打", "取长补短", "随心所欲"]

--- a/MeoAsstMac/Task Configurations/RoguelikeConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/RoguelikeConfiguration.swift
@@ -25,6 +25,10 @@ struct RoguelikeConfiguration: MAATaskConfiguration {
         case squad = 6
         /// 深入调查，尽可能稳定地打更多层数，不期而遇采用激进策略
         case exploration = 7
+
+        // ------------------ 黑流树海主题专用模式 ------------------
+        /// 刷襁褓动物
+        case blackFlowBabyAnimal = 30001
     }
 
     enum Theme: String, CaseIterable, Codable {
@@ -33,6 +37,15 @@ struct RoguelikeConfiguration: MAATaskConfiguration {
         case Sami
         case Sarkaz
         case JieGarden
+        case BlackFlow
+    }
+
+    /// 黑流树海襁褓动物目标品种
+    enum BlackFlowCultivationTarget: String, CaseIterable, Codable {
+        case cat = "swaddled_cat"
+        case featheredSerpent = "swaddled_feathered_serpent"
+        case dog = "swaddled_dog"
+        case cerberus = "swaddled_cerberus"
     }
 
     struct Difficulty: Hashable, Identifiable {
@@ -151,6 +164,10 @@ struct RoguelikeConfiguration: MAATaskConfiguration {
     ///
     /// 仅在模式为 `collectible` 时有效
     var collectible_mode_start_list: StartCollectibles
+    /// 刷襁褓动物模式的目标品种, 默认 `swaddled_cat`
+    ///
+    /// 仅在主题为 `BlackFlow` 且模式为 `blackFlowBabyAnimal` 时有效
+    var blackflow_cultivation_target: BlackFlowCultivationTarget
 
     var title: String {
         type.description
@@ -199,6 +216,8 @@ struct RoguelikeConfiguration: MAATaskConfiguration {
         let collectible_mode_shopping: Bool?
         let collectible_mode_squad: String?
         let collectible_mode_start_list: StartCollectibles?
+        let blackflow_strategy: String?
+        let blackflow_cultivation_target: String?
     }
 
     var params: Params {
@@ -219,10 +238,15 @@ extension RoguelikeConfiguration.Theme {
             return String(localized: "萨卡兹")
         case .JieGarden:
             return String(localized: "界园")
+        case .BlackFlow:
+            return String(localized: "黑流树海")
         }
     }
 
     var modes: [RoguelikeConfiguration.Mode] {
+        if self == .BlackFlow {
+            return [RoguelikeConfiguration.Mode.exp, .investment, .blackFlowBabyAnimal]
+        }
         let commonModes = [RoguelikeConfiguration.Mode.exp, .investment, .collectible, .squad, .exploration]
         if self == .Sami {
             return commonModes + [.clpPds]
@@ -247,6 +271,8 @@ extension RoguelikeConfiguration.Mode {
             String(localized: "月度小队")
         case .exploration:
             String(localized: "深入调查")
+        case .blackFlowBabyAnimal:
+            String(localized: "刷襁褓动物")
         }
     }
 }
@@ -319,6 +345,11 @@ extension RoguelikeConfiguration.Params {
         self.collectible_mode_shopping = config.mode == .collectible ? config.collectible_mode_shopping : nil
         self.collectible_mode_squad = config.mode == .collectible ? config.collectible_mode_squad : nil
         self.collectible_mode_start_list = config.mode == .collectible ? config.collectible_mode_start_list : nil
+        self.blackflow_strategy =
+            config.theme == .BlackFlow && config.mode == .blackFlowBabyAnimal ? "baby_animal" : nil
+        self.blackflow_cultivation_target =
+            config.theme == .BlackFlow && config.mode == .blackFlowBabyAnimal
+            ? config.blackflow_cultivation_target.rawValue : nil
     }
 }
 
@@ -370,5 +401,8 @@ extension RoguelikeConfiguration {
         self.collectible_mode_start_list =
             try container.decodeIfPresent(StartCollectibles.self, forKey: .collectible_mode_start_list)
             ?? StartCollectibles()
+        self.blackflow_cultivation_target =
+            try container.decodeIfPresent(BlackFlowCultivationTarget.self, forKey: .blackflow_cultivation_target)
+            ?? .cat
     }
 }


### PR DESCRIPTION
### 改动内容

为 macOS 版 GUI 新增**黑流树海**肉鸽主题支持（`Theme.BlackFlow`），共 2 个文件：

1. **`RoguelikeConfiguration.swift`**：
   - 新增 `Theme.BlackFlow` 主题，展示名「黑流树海」。
   - 新增黑流主题专用模式 `blackFlowBabyAnimal`（刷襁褓动物，`mode = 30001`）。
   - 新增 `BlackFlowCultivationTarget` 枚举（猫 / 羽蛇 / 狗 / 三头犬，对应 `swaddled_*` 资源键）。
   - BlackFlow 主题可用模式限定为 `exp / investment / blackFlowBabyAnimal`。
   - `params` 序列化：仅当 `theme == .BlackFlow && mode == .blackFlowBabyAnimal` 时输出 `blackflow_strategy = "baby_animal"` 与 `blackflow_cultivation_target`。

2. **`RoguelikeSettingsView.swift`**：
   - BlackFlow 主题展示专属「目标襁褓动物」选择器（仅刷襁褓动物模式）。
   - BlackFlow 主题屏蔽不适用的「投资后进二层」开关。
   - BlackFlow 的分队列表（特勤 / 矛头 / 高台突破 … 堡垒战术等 15 个）、定位列表（含「稳扎稳打」「坚不可摧」等 6 个）与难度上限（15）接入主题化配置。

### 验证

- 基于官方 `master`（`791a95f8`）仅 cherry-pick 本提交，构建通过、启动无崩溃。
- 与「日志显示对齐 Windows 版」的工作线（`feat/log-display-windows`）文件零重叠，互不影响。

### 备注

本 PR 只提供 **GUI 侧入口**（主题、模式、参数透传）。对应的黑流树海核心实现（C++ 与资源文件）尚未合并到官方 MAA 核心仓库，需核心支持后该主题才可实际运行。

## Summary by Sourcery

为 macOS 添加 GUI 支持，用于配置 BlackFlow roguelike 主题及其幼年动物养成模式。

新功能：
- 添加 BlackFlow roguelike 主题，包含专门的幼年动物养成模式和目标选择功能。

增强内容：
- 配置 BlackFlow 专属的小队、角色、难度上限和模式可用性，同时隐藏不兼容的投资设置。
- 序列化 BlackFlow 幼年动物策略和养成目标，用于核心任务配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add macOS GUI support for configuring the BlackFlow roguelike theme and its baby-animal cultivation mode.

New Features:
- Add the BlackFlow roguelike theme with dedicated baby-animal cultivation mode and target selection.

Enhancements:
- Configure BlackFlow-specific squads, roles, difficulty limits, and mode availability while hiding incompatible investment settings.
- Serialize BlackFlow baby-animal strategy and cultivation targets for core task configuration.

</details>