### PR TITLE
feat: 支持库存保持任务

### DIFF
--- a/MeoAsstMac.xcodeproj/project.pbxproj
+++ b/MeoAsstMac.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		8307A5CF3030157700A82FF7 /* PixelPainter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8307A5CE3030157600A82FF7 /* PixelPainter.swift */; };
+		9BD000112F10000100000001 /* DepotMaintainConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD000012F10000100000001 /* DepotMaintainConfiguration.swift */; };
+		9BD000122F10000100000001 /* DepotMaintainSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD000022F10000100000001 /* DepotMaintainSettingsView.swift */; };
+		9BD000132F10000100000001 /* FightStageSchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD000032F10000100000001 /* FightStageSchedule.swift */; };
 		830C3D1C29BC7D8600B13A9F /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 830C3D1B29BC7D8600B13A9F /* Sparkle */; };
 		830C3D1E29BC7DE200B13A9F /* CheckForUpdatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830C3D1D29BC7DE200B13A9F /* CheckForUpdatesView.swift */; };
 		831100C43026440D00554899 /* NewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831100C33026440D00554899 /* NewViewModel.swift */; };
@@ -140,6 +143,9 @@
 
 /* Begin PBXFileReference section */
 		8307A5CE3030157600A82FF7 /* PixelPainter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelPainter.swift; sourceTree = "<group>"; };
+		9BD000012F10000100000001 /* DepotMaintainConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepotMaintainConfiguration.swift; sourceTree = "<group>"; };
+		9BD000022F10000100000001 /* DepotMaintainSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepotMaintainSettingsView.swift; sourceTree = "<group>"; };
+		9BD000032F10000100000001 /* FightStageSchedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FightStageSchedule.swift; sourceTree = "<group>"; };
 		830C3D1D29BC7DE200B13A9F /* CheckForUpdatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckForUpdatesView.swift; sourceTree = "<group>"; };
 		830C3D1F29BC86EE00B13A9F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		831100C33026440D00554899 /* NewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewViewModel.swift; sourceTree = "<group>"; };
@@ -276,6 +282,7 @@
 			isa = PBXGroup;
 			children = (
 				83264A2829EBEBB00074E33A /* MAATaskConfiguration.swift */,
+				9BD000012F10000100000001 /* DepotMaintainConfiguration.swift */,
 				83264A2A29EBED780074E33A /* StartupConfiguration.swift */,
 				834DEC112C4D94BD0073B5D4 /* ClosedownConfiguration.swift */,
 				83264A2C29EBEDD80074E33A /* FightConfiguration.swift */,
@@ -294,6 +301,7 @@
 		83264A3629EBF0700074E33A /* Configuration Views */ = {
 			isa = PBXGroup;
 			children = (
+				9BD000022F10000100000001 /* DepotMaintainSettingsView.swift */,
 				8315B0BC290E48F300AE7FDC /* StartupSettingsView.swift */,
 				83D3283028F2E7A600018D10 /* RecruitSettingsView.swift */,
 				83D3283628F2FA5B00018D10 /* InfrastSettingsView.swift */,
@@ -442,6 +450,7 @@
 		8341195129EC258D00044F45 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				9BD000032F10000100000001 /* FightStageSchedule.swift */,
 				8341195629EC58CF00044F45 /* MAACopilot.swift */,
 				832985B529EF1890009F7ED5 /* MAADepot.swift */,
 				838FF82829FDE1FA000566A0 /* MAAError.swift */,
@@ -590,6 +599,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9BD000112F10000100000001 /* DepotMaintainConfiguration.swift in Sources */,
+				9BD000122F10000100000001 /* DepotMaintainSettingsView.swift in Sources */,
+				9BD000132F10000100000001 /* FightStageSchedule.swift in Sources */,
 				8341195D29EC719B00044F45 /* CopilotContent.swift in Sources */,
 				8355E7B429E918A2005D5A1C /* TasksContent.swift in Sources */,
 				832985AA29EE9958009F7ED5 /* RecruitView.swift in Sources */,

--- a/MeoAsstMac/Configuration Views/DepotMaintainSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/DepotMaintainSettingsView.swift
@@ -250,21 +250,18 @@ struct DepotMaintainSettingsView: View {
         Binding {
             plan.wrappedValue.stage
         } set: { stage in
+            let stage = FightStageSchedule.normalizedStage(stage)
             plan.wrappedValue.stage = stage
             let dropID = plan.wrappedValue.dropID
-            if !dropID.isEmpty, stageDropIDs[normalizedStage(stage)]?.contains(dropID) != true {
+            if !dropID.isEmpty, stageDropIDs[stage]?.contains(dropID) != true {
                 plan.wrappedValue.dropID = ""
             }
         }
     }
 
     private func dropItems(for stage: String) -> [(id: String, name: String)] {
-        guard let allowedIDs = stageDropIDs[normalizedStage(stage)] else { return [] }
+        guard let allowedIDs = stageDropIDs[FightStageSchedule.normalizedStage(stage)] else { return [] }
         return dropItems.filter { allowedIDs.contains($0.id) }
-    }
-
-    private func normalizedStage(_ stage: String) -> String {
-        stage.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
     }
 
     private var stageChoices: [String] {
@@ -314,7 +311,7 @@ struct DepotMaintainSettingsView: View {
             let records = try JSONDecoder().decode([StageRecord].self, from: Data(contentsOf: url))
             var result = [String: Set<String>]()
             for record in records {
-                let stage = normalizedStage(record.code)
+                let stage = FightStageSchedule.normalizedStage(record.code)
                 result[stage, default: []].formUnion(record.dropInfos.map(\.itemId))
 
                 // stages.json does not list the fixed currencies from these resource stages.
@@ -326,7 +323,8 @@ struct DepotMaintainSettingsView: View {
             }
             stageDropIDs = result
             for index in config.plans.indices {
-                let stage = normalizedStage(config.plans[index].stage)
+                let stage = FightStageSchedule.normalizedStage(config.plans[index].stage)
+                config.plans[index].stage = stage
                 let dropID = config.plans[index].dropID
                 if let allowedIDs = result[stage], !dropID.isEmpty, !allowedIDs.contains(dropID) {
                     config.plans[index].dropID = ""

--- a/MeoAsstMac/Configuration Views/DepotMaintainSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/DepotMaintainSettingsView.swift
@@ -1,0 +1,346 @@
+//
+//  DepotMaintainSettingsView.swift
+//  MAA
+//
+
+import SwiftUI
+
+struct DepotMaintainSettingsView: View {
+    @EnvironmentObject private var viewModel: MAAViewModel
+    @Binding var config: DepotMaintainConfiguration
+
+    @State private var expandedPlanIDs = Set<UUID>()
+    @State private var dropItems = [(id: String, name: String)]()
+    @State private var dropNames = [String: String]()
+    @State private var stageDropIDs = [String: Set<String>]()
+    @State private var showClearConfirmation = false
+    @State private var settingsPage = SettingsPage.general
+
+    private enum SettingsPage: Hashable {
+        case general
+        case advanced
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Group {
+                switch settingsPage {
+                case .general:
+                    generalSettings
+                case .advanced:
+                    advancedSettings
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            Divider()
+            Picker("设置页面", selection: $settingsPage) {
+                Text("常规设置").tag(SettingsPage.general)
+                Text("高级设置").tag(SettingsPage.advanced)
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+            .frame(width: 240)
+            .padding(.vertical, 8)
+        }
+        .disabled(viewModel.status != .idle)
+        .onAppear(perform: loadDropItems)
+        .alert("清空全部计划？", isPresented: $showClearConfirmation) {
+            Button("取消", role: .cancel) {}
+            Button("清空", role: .destructive) {
+                config.plans.removeAll()
+                expandedPlanIDs.removeAll()
+            }
+        } message: {
+            Text("此操作无法撤销。")
+        }
+    }
+
+    private var generalSettings: some View {
+        Form {
+            Section {
+                if config.plans.isEmpty {
+                    VStack(spacing: 8) {
+                        Image(systemName: "shippingbox")
+                            .font(.title)
+                            .foregroundStyle(.secondary)
+                        Text("暂无计划")
+                            .font(.headline)
+                        Text("添加计划或使用预设来设定目标库存。")
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 110)
+                } else {
+                    List {
+                        ForEach($config.plans) { $plan in
+                            planEditor(plan: $plan)
+                        }
+                        .onMove { source, destination in
+                            config.plans.move(fromOffsets: source, toOffset: destination)
+                        }
+                    }
+                    .frame(minHeight: 220, idealHeight: 380)
+                }
+
+                HStack(spacing: 0) {
+                    Button("全部折叠") {
+                        expandedPlanIDs.removeAll()
+                    }
+                    .disabled(expandedPlanIDs.isEmpty)
+
+                    Button("清空") {
+                        showClearConfirmation = true
+                    }
+                    .disabled(config.plans.isEmpty)
+
+                    Button {
+                        let plan = DepotMaintainConfiguration.Plan()
+                        config.plans.append(plan)
+                        expandedPlanIDs.insert(plan.id)
+                    } label: {
+                        Label("添加计划", systemImage: "plus")
+                    }
+
+                    Menu("预设") {
+                        ForEach(DepotMaintainConfiguration.Preset.allCases) { preset in
+                            Button(preset.title) {
+                                let plans = preset.plans
+                                config.plans.append(contentsOf: plans)
+                                expandedPlanIDs.formUnion(plans.map(\.id))
+                            }
+                        }
+                    }
+                }
+                .buttonStyle(.bordered)
+            } header: {
+                Text("计划")
+            } footer: {
+                Text("计划可拖拽排序；每条计划开始前都会按最新库存重新计算缺口。")
+            }
+        }
+    }
+
+    private var advancedSettings: some View {
+        Form {
+            Section("任务行为") {
+                Toggle("任务开始前更新库存数据", isOn: $config.updateDepot)
+                Toggle("活动期间跳过", isOn: $config.skipDuringActivity)
+                Toggle("资源收集限时全天开放期间跳过", isOn: $config.skipDuringResourceCollection)
+            }
+
+            Section("关卡与作战") {
+                Toggle("AUTO 代理倍率", isOn: $config.useAutoSeries)
+                    .help("开启后使用当前理智允许的最大代理倍率，单次掉落可能超过目标库存。")
+            }
+
+            Section("理智恢复") {
+                Toggle("启用「使用药剂」勾选框", isOn: $config.enableMedicine)
+                Toggle("启用「使用源石」勾选框", isOn: $config.enableStone)
+                Toggle("使用 48 小时内过期的理智药", isOn: $config.useExpiringMedicine)
+                    .help("对全部计划生效，包括没有单独设置药剂预算的计划。")
+            }
+        }
+    }
+
+    private func planEditor(plan: Binding<DepotMaintainConfiguration.Plan>) -> some View {
+        let id = plan.wrappedValue.id
+        let index = config.plans.firstIndex { $0.id == id }.map { $0 + 1 } ?? 0
+        let current = viewModel.depot?.count(of: plan.wrappedValue.dropID)
+
+        return DisclosureGroup(isExpanded: expansionBinding(for: id)) {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    TextField("关卡编号", text: stageBinding(for: plan))
+                    Menu {
+                        ForEach(stageChoices, id: \.self) { stage in
+                            Button(stage) { stageBinding(for: plan).wrappedValue = stage }
+                        }
+                    } label: {
+                        Image(systemName: "list.bullet")
+                    }
+                    .menuStyle(.borderlessButton)
+                    .help("选择常用关卡")
+                }
+
+                HStack(spacing: 8) {
+                    Picker("指定掉落物", selection: plan.dropID) {
+                        Text("请选择").tag("")
+                        ForEach(dropItems(for: plan.wrappedValue.stage), id: \.id) { item in
+                            Text(item.name).tag(item.id)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+
+                    TextField("目标库存", value: plan.target, format: .number)
+                        .frame(width: 110)
+                }
+
+                if config.enableMedicine {
+                    HStack {
+                        Toggle("使用药剂", isOn: plan.useMedicine)
+                            .help("设置预算后，本计划不会因预估理智不足而提前跳过。")
+                        Spacer()
+                        Stepper(value: plan.medicineCount, in: 0...999) {
+                            TextField("数量", value: plan.medicineCount, format: .number)
+                                .labelsHidden()
+                                .multilineTextAlignment(.trailing)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 70)
+                        }
+                        .fixedSize()
+                        .help("本计划最多使用的理智药数量；未勾选时不会实际使用。")
+                    }
+                }
+
+                if config.enableStone {
+                    HStack {
+                        Toggle("使用源石", isOn: plan.useStone)
+                            .help("设置预算后，本计划不会因预估理智不足而提前跳过。")
+                        Spacer()
+                        Stepper(value: plan.stoneCount, in: 0...999) {
+                            TextField("数量", value: plan.stoneCount, format: .number)
+                                .labelsHidden()
+                                .multilineTextAlignment(.trailing)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 70)
+                        }
+                        .fixedSize()
+                        .help("本计划最多使用的源石数量；未勾选时不会实际使用。")
+                    }
+                }
+            }
+            .padding(.vertical, 6)
+        } label: {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(
+                        "\(index): \(plan.wrappedValue.stage.isEmpty ? String(localized: "未选择关卡") : plan.wrappedValue.stage) - \(dropName(for: plan.wrappedValue.dropID)) ×\(plan.wrappedValue.target)"
+                    )
+                    .lineLimit(1)
+                    Text("库存 \(current.map(String.init) ?? "--") / \(plan.wrappedValue.target)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button(role: .destructive) {
+                    config.plans.removeAll { $0.id == id }
+                    expandedPlanIDs.remove(id)
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.borderless)
+                .help("删除计划")
+            }
+        }
+    }
+
+    private func expansionBinding(for id: UUID) -> Binding<Bool> {
+        Binding {
+            expandedPlanIDs.contains(id)
+        } set: { expanded in
+            if expanded {
+                expandedPlanIDs.insert(id)
+            } else {
+                expandedPlanIDs.remove(id)
+            }
+        }
+    }
+
+    private func stageBinding(for plan: Binding<DepotMaintainConfiguration.Plan>) -> Binding<String> {
+        Binding {
+            plan.wrappedValue.stage
+        } set: { stage in
+            plan.wrappedValue.stage = stage
+            let dropID = plan.wrappedValue.dropID
+            if !dropID.isEmpty, stageDropIDs[normalizedStage(stage)]?.contains(dropID) != true {
+                plan.wrappedValue.dropID = ""
+            }
+        }
+    }
+
+    private func dropItems(for stage: String) -> [(id: String, name: String)] {
+        guard let allowedIDs = stageDropIDs[normalizedStage(stage)] else { return [] }
+        return dropItems.filter { allowedIDs.contains($0.id) }
+    }
+
+    private func normalizedStage(_ stage: String) -> String {
+        stage.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+    }
+
+    private var stageChoices: [String] {
+        let common = [
+            "1-7", "R8-11", "12-17-HARD",
+            "LS-6", "CE-6", "AP-5", "CA-5", "SK-5",
+            "PR-A-1", "PR-A-2", "PR-B-1", "PR-B-2",
+            "PR-C-1", "PR-C-2", "PR-D-1", "PR-D-2",
+            "OF-1", "OF-F3",
+        ]
+        let activityStages = viewModel.stageActivity?.fightScheduleData.activeStageValues(at: Date()) ?? []
+        return Array(Set(common + activityStages)).sorted()
+    }
+
+    private func dropName(for id: String) -> String {
+        guard !id.isEmpty else { return String(localized: "未选择材料") }
+        return dropNames[id] ?? id
+    }
+
+    private func loadDropItems() {
+        do {
+            try FightConfiguration.initDropItems(Bundle.main.preferredLocalizations.first ?? "zh-cn")
+            dropItems = FightConfiguration.dropItems.map { ($0.id, $0.item.name) }
+            dropNames = Dictionary(uniqueKeysWithValues: dropItems.map { ($0.id, $0.name) })
+            loadStageDrops()
+        } catch {
+            print(String(localized: "Read item_index.json failed: \(error.localizedDescription)"))
+        }
+    }
+
+    private func loadStageDrops() {
+        struct StageRecord: Decodable {
+            struct DropInfo: Decodable {
+                let itemId: String
+            }
+
+            let code: String
+            let dropInfos: [DropInfo]
+        }
+
+        let external = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("resource/stages.json")
+        let bundled = Bundle.main.resourceURL!.appendingPathComponent("resource/stages.json")
+        let url = FileManager.default.fileExists(atPath: external.path) ? external : bundled
+
+        do {
+            let records = try JSONDecoder().decode([StageRecord].self, from: Data(contentsOf: url))
+            var result = [String: Set<String>]()
+            for record in records {
+                let stage = normalizedStage(record.code)
+                result[stage, default: []].formUnion(record.dropInfos.map(\.itemId))
+
+                // stages.json does not list the fixed currencies from these resource stages.
+                if stage.hasPrefix("CE-") {
+                    result[stage, default: []].insert("4001")
+                } else if stage.hasPrefix("AP-") {
+                    result[stage, default: []].insert("4006")
+                }
+            }
+            stageDropIDs = result
+            for index in config.plans.indices {
+                let stage = normalizedStage(config.plans[index].stage)
+                let dropID = config.plans[index].dropID
+                if let allowedIDs = result[stage], !dropID.isEmpty, !allowedIDs.contains(dropID) {
+                    config.plans[index].dropID = ""
+                }
+            }
+        } catch {
+            print(String(localized: "Read stages.json failed: \(error.localizedDescription)"))
+        }
+    }
+}
+
+struct DepotMaintainSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        DepotMaintainSettingsView(config: .constant(.init()))
+            .environmentObject(MAAViewModel())
+    }
+}

--- a/MeoAsstMac/Core/Maa.swift
+++ b/MeoAsstMac/Core/Maa.swift
@@ -185,6 +185,7 @@ enum MAATaskType: String {
     case Recruit
     case Infrast
     case Fight
+    case DepotMaintain
     case Mall
     case Award
     case Roguelike
@@ -208,6 +209,7 @@ enum MaaCoreError: Error {
     case connectFailed
     case getImageFailed
     case asyncCallFailed
+    case uiOnlyTask
 }
 
 enum MAAInstanceOptionKey: Int32 {
@@ -266,6 +268,8 @@ extension MAAResourceVersion {
 
 struct MAAStageActivity: Decodable, Hashable {
     let miniGame: [MiniGame]
+    let resourceCollection: TimedActivity?
+    let sideStoryStage: [String: SideStory]?
 
     struct MiniGame: Decodable, Hashable {
         let Display: String?
@@ -277,6 +281,48 @@ struct MAAStageActivity: Decodable, Hashable {
         private let UtcStartTime: String?
         private let UtcExpireTime: String?
         private let TimeZone: Double?
+    }
+
+    struct TimedActivity: Decodable, Hashable {
+        private let utcStartTime: String
+        private let utcExpireTime: String
+        private let timeZone: Double
+
+        private enum CodingKeys: String, CodingKey {
+            case utcStartTime = "UtcStartTime"
+            case utcExpireTime = "UtcExpireTime"
+            case timeZone = "TimeZone"
+        }
+
+        var window: FightStageSchedule.ActivityWindow? {
+            guard let parser = dateParser,
+                let start = try? parser.parse(utcStartTime),
+                let expire = try? parser.parse(utcExpireTime)
+            else { return nil }
+            return .init(start: start, expire: expire)
+        }
+
+        private var dateParser: Date.ParseStrategy? {
+            .maaActivity(timeZone: timeZone)
+        }
+    }
+
+    struct SideStory: Decodable, Hashable {
+        let activity: TimedActivity
+        let stages: [Stage]
+
+        private enum CodingKeys: String, CodingKey {
+            case activity = "Activity"
+            case stages = "Stages"
+        }
+
+        struct Stage: Decodable, Hashable {
+            let value: String
+
+            private enum CodingKeys: String, CodingKey {
+                case value = "Value"
+            }
+        }
     }
 }
 
@@ -303,5 +349,15 @@ extension MAAStageActivity.MiniGame {
             format:
                 "\(year: .defaultDigits)/\(month: .twoDigits)/\(day: .twoDigits) \(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits):\(second: .twoDigits)",
             timeZone: .init(secondsFromGMT: Int(TimeZone * 3600))!)
+    }
+}
+
+extension Date.ParseStrategy {
+    fileprivate static func maaActivity(timeZone: Double) -> Self? {
+        guard let zone = Foundation.TimeZone(secondsFromGMT: Int(timeZone * 3_600)) else { return nil }
+        return .init(
+            format:
+                "\(year: .defaultDigits)/\(month: .twoDigits)/\(day: .twoDigits) \(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits):\(second: .twoDigits)",
+            timeZone: zone)
     }
 }

--- a/MeoAsstMac/Core/MaaMessage.swift
+++ b/MeoAsstMac/Core/MaaMessage.swift
@@ -374,8 +374,7 @@ extension MAAViewModel {
             var allDrops = [String]()
             var depotDrops = [(id: String, name: String, quantity: Int)]()
             for item in statistics {
-                guard let itemID = item["itemId"].string,
-                    let name = item["itemName"].string,
+                guard let name = item["itemName"].string,
                     let total = item["quantity"].int,
                     let addition = item["addQuantity"].int
                 else {
@@ -387,7 +386,10 @@ extension MAAViewModel {
                     drop += " (+\(addition))"
                 }
                 allDrops.append(drop)
-                depotDrops.append((itemID, name, addition))
+                let reportedItemID = item["itemId"].string.flatMap { $0.isEmpty ? nil : $0 }
+                if let itemID = reportedItemID ?? stageDropItemID(named: name) {
+                    depotDrops.append((itemID, name, addition))
+                }
             }
 
             if var depot {
@@ -573,6 +575,55 @@ extension MAAViewModel {
         default:
             break
         }
+    }
+
+    private func stageDropItemID(named name: String) -> String? {
+        if let itemID = depot?.itemID(named: name) {
+            return itemID
+        }
+        if legacyStageDropItemIDsByName == nil {
+            legacyStageDropItemIDsByName = loadStageDropItemIDsByName()
+        }
+        return legacyStageDropItemIDsByName?[name]
+    }
+
+    private func loadStageDropItemIDsByName() -> [String: String] {
+        struct ItemRecord: Decodable {
+            let name: String
+        }
+
+        let resourcePaths = [
+            clientChannel.isGlobal
+                ? "resource/global/\(clientChannel.rawValue)/resource/item_index.json"
+                : "resource/item_index.json",
+            "resource/item_index.json",
+            "resource/global/txwy/resource/item_index.json",
+            "resource/global/YoStarEN/resource/item_index.json",
+            "resource/global/YoStarJP/resource/item_index.json",
+            "resource/global/YoStarKR/resource/item_index.json",
+        ]
+        var roots = [URL]()
+        if let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+            roots.append(documents)
+        }
+        if let bundled = Bundle.main.resourceURL {
+            roots.append(bundled)
+        }
+
+        var result = [String: String]()
+        for root in roots {
+            for path in resourcePaths {
+                let url = root.appendingPathComponent(path)
+                guard let data = try? Data(contentsOf: url),
+                    let items = try? JSONDecoder().decode([String: ItemRecord].self, from: data)
+                else { continue }
+
+                for (itemID, item) in items where result[item.name] == nil {
+                    result[item.name] = itemID
+                }
+            }
+        }
+        return result
     }
 
     // MARK: Recruit Recoginition

--- a/MeoAsstMac/Core/MaaMessage.swift
+++ b/MeoAsstMac/Core/MaaMessage.swift
@@ -110,7 +110,7 @@ extension MAAViewModel {
 
         let isCopilot = ["Copilot", "VideoRecognition"].contains(taskChain)
 
-        if taskChain == "CloseDown" {
+        if taskChain == "CloseDown", !isExecutingDailyQueue {
             Task {
                 try await stop()
             }
@@ -178,8 +178,10 @@ extension MAAViewModel {
             break
 
         case .AllTasksCompleted:
-            logTrace("AllTasksComplete")
-            resetStatus()
+            if !isExecutingDailyQueue {
+                logTrace("AllTasksComplete")
+                resetStatus()
+            }
 
         default:
             break
@@ -370,8 +372,10 @@ extension MAAViewModel {
             }
 
             var allDrops = [String]()
+            var depotDrops = [(id: String, name: String, quantity: Int)]()
             for item in statistics {
-                guard let name = item["itemName"].string,
+                guard let itemID = item["itemId"].string,
+                    let name = item["itemName"].string,
                     let total = item["quantity"].int,
                     let addition = item["addQuantity"].int
                 else {
@@ -383,6 +387,12 @@ extension MAAViewModel {
                     drop += " (+\(addition))"
                 }
                 allDrops.append(drop)
+                depotDrops.append((itemID, name, addition))
+            }
+
+            if var depot {
+                depot.addDrops(depotDrops)
+                self.depot = depot
             }
 
             if allDrops.count == 0 {
@@ -542,8 +552,17 @@ extension MAAViewModel {
             }
 
         case "SanityBeforeStage":
-            if let curSanityBeforeFight = subTaskDetails["current_sanity"].int {
+            if let curSanityBeforeFight = subTaskDetails["current_sanity"].int,
+                let maximum = subTaskDetails["max_sanity"].int,
+                maximum > 0
+            {
                 self.curSanityBeforeFight = curSanityBeforeFight
+                let formatter = DateFormatter()
+                formatter.locale = Locale(identifier: "en_US_POSIX")
+                formatter.timeZone = .current
+                formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+                let reportedAt = subTaskDetails["report_time"].string.flatMap(formatter.date(from:)) ?? Date()
+                sanityReport = .init(current: curSanityBeforeFight, maximum: maximum, reportedAt: reportedAt)
             }
 
         case "FightTimes":

--- a/MeoAsstMac/Model/FightStageSchedule.swift
+++ b/MeoAsstMac/Model/FightStageSchedule.swift
@@ -41,7 +41,9 @@ struct FightStageSchedule: Sendable {
 
         init(resourceCollection: ActivityWindow? = nil, stageWindows: [String: ActivityWindow] = [:]) {
             self.resourceCollection = resourceCollection
-            self.stageWindows = stageWindows
+            self.stageWindows = Dictionary(
+                stageWindows.map { (FightStageSchedule.normalizedStage($0.key), $0.value) },
+                uniquingKeysWith: { first, _ in first })
         }
 
         func activeStageValues(at date: Date) -> [String] {
@@ -64,7 +66,12 @@ struct FightStageSchedule: Sendable {
         "PR-D-1": [1, 3, 4, 7], "PR-D-2": [1, 3, 4, 7],
     ]
 
+    static func normalizedStage(_ stage: String) -> String {
+        stage.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+    }
+
     func isOpen(_ stage: String, server: Server, activities: ActivityData?, at date: Date = Date()) -> Bool {
+        let stage = Self.normalizedStage(stage)
         if let window = activities?.stageWindows[stage] {
             return window.contains(date)
         }

--- a/MeoAsstMac/Model/FightStageSchedule.swift
+++ b/MeoAsstMac/Model/FightStageSchedule.swift
@@ -1,0 +1,108 @@
+//
+//  FightStageSchedule.swift
+//  MAA
+//
+
+import Foundation
+
+struct FightStageSchedule: Sendable {
+    enum Server: Sendable {
+        case official
+        case yoStarEN
+        case yoStarJP
+        case yoStarKR
+        case txwy
+
+        fileprivate var timeZone: TimeZone {
+            let identifier =
+                switch self {
+                case .official: "Asia/Shanghai"
+                case .yoStarEN: "America/Los_Angeles"
+                case .yoStarJP: "Asia/Tokyo"
+                case .yoStarKR: "Asia/Seoul"
+                case .txwy: "Asia/Taipei"
+                }
+            return TimeZone(identifier: identifier)!
+        }
+    }
+
+    struct ActivityWindow: Hashable, Sendable {
+        let start: Date
+        let expire: Date
+
+        func contains(_ date: Date) -> Bool {
+            start <= date && date <= expire
+        }
+    }
+
+    struct ActivityData: Hashable, Sendable {
+        var resourceCollection: ActivityWindow?
+        var stageWindows: [String: ActivityWindow]
+
+        init(resourceCollection: ActivityWindow? = nil, stageWindows: [String: ActivityWindow] = [:]) {
+            self.resourceCollection = resourceCollection
+            self.stageWindows = stageWindows
+        }
+
+        func activeStageValues(at date: Date) -> [String] {
+            stageWindows.compactMap { $0.value.contains(date) ? $0.key : nil }.sorted()
+        }
+
+        func hasActiveSideStory(at date: Date) -> Bool {
+            stageWindows.values.contains { $0.contains(date) }
+        }
+    }
+
+    private static let weeklyOpenDays: [String: Set<Int>] = [
+        "CE-6": [1, 3, 5, 7],
+        "AP-5": [1, 2, 5, 7],
+        "CA-5": [1, 3, 4, 6],
+        "SK-5": [2, 4, 6, 7],
+        "PR-A-1": [1, 2, 5, 6], "PR-A-2": [1, 2, 5, 6],
+        "PR-B-1": [2, 3, 6, 7], "PR-B-2": [2, 3, 6, 7],
+        "PR-C-1": [1, 4, 5, 7], "PR-C-2": [1, 4, 5, 7],
+        "PR-D-1": [1, 3, 4, 7], "PR-D-2": [1, 3, 4, 7],
+    ]
+
+    func isOpen(_ stage: String, server: Server, activities: ActivityData?, at date: Date = Date()) -> Bool {
+        if let window = activities?.stageWindows[stage] {
+            return window.contains(date)
+        }
+        guard let openDays = Self.weeklyOpenDays[stage] else { return true }
+        if activities?.resourceCollection?.contains(date) == true { return true }
+        return openDays.contains(serverWeekday(server, at: date))
+    }
+
+    func serverWeekday(_ server: Server, at date: Date) -> Int {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = server.timeZone
+        let weekday = calendar.component(.weekday, from: date)
+        guard calendar.component(.hour, from: date) < 4 else { return weekday }
+        return weekday == 1 ? 7 : weekday - 1
+    }
+}
+
+extension MAAClientChannel {
+    var fightStageServer: FightStageSchedule.Server {
+        switch self {
+        case .Official, .Bilibili: .official
+        case .YoStarEN: .yoStarEN
+        case .YoStarJP: .yoStarJP
+        case .YoStarKR: .yoStarKR
+        case .txwy: .txwy
+        }
+    }
+}
+
+extension MAAStageActivity {
+    var fightScheduleData: FightStageSchedule.ActivityData {
+        var stageWindows = [String: FightStageSchedule.ActivityWindow]()
+        if let sideStoryStage {
+            for sideStory in sideStoryStage.values {
+                guard let window = sideStory.activity.window else { continue }
+                for stage in sideStory.stages { stageWindows[stage.value] = window }
+            }
+        }
+        return .init(resourceCollection: resourceCollection?.window, stageWindows: stageWindows)
+    }
+}

--- a/MeoAsstMac/Model/MAADepot.swift
+++ b/MeoAsstMac/Model/MAADepot.swift
@@ -94,6 +94,10 @@ struct MAADepot: Codable {
         cachedInventory[itemID]
     }
 
+    func itemID(named name: String) -> String? {
+        arkplanner.object.items.first { $0.name == name }?.id
+    }
+
     mutating func addDrops(_ drops: [(id: String, name: String, quantity: Int)]) {
         for drop in drops where drop.quantity > 0 && Int(drop.id) != nil {
             let newCount = (cachedInventory[drop.id] ?? 0) + drop.quantity

--- a/MeoAsstMac/Model/MAADepot.swift
+++ b/MeoAsstMac/Model/MAADepot.swift
@@ -9,27 +9,107 @@ import Foundation
 
 struct MAADepot: Codable {
     let done: Bool
-    let arkplanner: Arkplanner
-    let lolicon: Lolicon
-    
+    var arkplanner: Arkplanner
+    var lolicon: Lolicon
+    private var cachedInventory: [String: Int]
+
     struct Arkplanner: Codable {
-        let object: ArkplannerObject
-        let data: String
+        var object: ArkplannerObject
+        var data: String
+
+        init(object: ArkplannerObject = .init(items: []), data: String = "") {
+            self.object = object
+            self.data = data
+        }
     }
-    
+
     struct ArkplannerObject: Codable {
-        let items: [ArkplannerItem]
+        var items: [ArkplannerItem]
     }
-    
+
     struct ArkplannerItem: Codable {
         let id: String
-        let have: Int
-        let name: String
+        var have: Int
+        var name: String
     }
-    
+
     struct Lolicon: Codable {
-        let object: [String: Int]
-        let data: String
+        var object: [String: Int]
+        var data: String
+
+        init(object: [String: Int] = [:], data: String = "") {
+            self.object = object
+            self.data = data
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case done
+        case arkplanner
+        case lolicon
+        case data
+        case cachedInventory
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        done = try container.decodeIfPresent(Bool.self, forKey: .done) ?? false
+        arkplanner = try container.decodeIfPresent(Arkplanner.self, forKey: .arkplanner) ?? .init()
+        lolicon = try container.decodeIfPresent(Lolicon.self, forKey: .lolicon) ?? .init()
+
+        if let cached = try container.decodeIfPresent([String: Int].self, forKey: .cachedInventory) {
+            cachedInventory = cached
+        } else if let data = try? container.decode([String: Int].self, forKey: .data) {
+            cachedInventory = data
+        } else if let data = try? container.decode(String.self, forKey: .data),
+            let raw = data.data(using: .utf8),
+            let parsed = try? JSONDecoder().decode([String: Int].self, from: raw)
+        {
+            cachedInventory = parsed
+        } else if !arkplanner.object.items.isEmpty {
+            cachedInventory = Dictionary(uniqueKeysWithValues: arkplanner.object.items.map { ($0.id, $0.have) })
+        } else {
+            cachedInventory = lolicon.object
+        }
+
+        if arkplanner.object.items.isEmpty {
+            arkplanner.object.items = cachedInventory.map {
+                .init(id: $0.key, have: $0.value, name: $0.key)
+            }
+        }
+        if lolicon.object.isEmpty {
+            lolicon.object = cachedInventory
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(done, forKey: .done)
+        try container.encode(arkplanner, forKey: .arkplanner)
+        try container.encode(lolicon, forKey: .lolicon)
+        try container.encode(cachedInventory, forKey: .cachedInventory)
+    }
+
+    func count(of itemID: String) -> Int? {
+        cachedInventory[itemID]
+    }
+
+    mutating func addDrops(_ drops: [(id: String, name: String, quantity: Int)]) {
+        for drop in drops where drop.quantity > 0 && Int(drop.id) != nil {
+            let newCount = (cachedInventory[drop.id] ?? 0) + drop.quantity
+            cachedInventory[drop.id] = newCount
+            lolicon.object[drop.id] = newCount
+
+            if let index = arkplanner.object.items.firstIndex(where: { $0.id == drop.id }) {
+                arkplanner.object.items[index].have = newCount
+            } else {
+                arkplanner.object.items.append(.init(id: drop.id, have: newCount, name: drop.name))
+            }
+        }
+
+        if let data = try? JSONEncoder().encode(lolicon.object) {
+            lolicon.data = String(data: data, encoding: .utf8) ?? lolicon.data
+        }
     }
 }
 
@@ -39,7 +119,7 @@ extension MAADepot: CustomStringConvertible {
             .sorted { $0.id < $1.id }
             .map { "\($0.name): \($0.have)" }
     }
-    
+
     var description: String {
         contents.joined(separator: "\n")
     }

--- a/MeoAsstMac/Model/MAATask.swift
+++ b/MeoAsstMac/Model/MAATask.swift
@@ -13,6 +13,7 @@ enum MAATask: Codable, Equatable {
     case recruit(RecruitConfiguration)
     case infrast(InfrastConfiguration)
     case fight(FightConfiguration)
+    case depotMaintain(DepotMaintainConfiguration)
     case mall(MallConfiguration)
     case award(AwardConfiguration)
     case roguelike(RoguelikeConfiguration)
@@ -24,6 +25,7 @@ let defaultTaskConfigurations: [any MAATaskConfiguration] = [
     RecruitConfiguration(),
     InfrastConfiguration(),
     FightConfiguration(),
+    DepotMaintainConfiguration(),
     MallConfiguration(),
     AwardConfiguration(),
     RoguelikeConfiguration(),
@@ -44,6 +46,8 @@ extension MAATaskType: Codable, CustomStringConvertible {
             return String(localized: "基建换班")
         case .Fight:
             return String(localized: "刷理智")
+        case .DepotMaintain:
+            return String(localized: "库存保持")
         case .Mall:
             return String(localized: "收取信用及购物")
         case .Award:

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -27,6 +27,18 @@ import SwiftUI
     /// Sanity cost of current fight(s)
     var sanityCost = 0
 
+    struct SanityReport {
+        let current: Int
+        let maximum: Int
+        let reportedAt: Date
+    }
+
+    var sanityReport: SanityReport?
+    private var provenExhaustedMedicineDays = 0
+    var isExecutingDailyQueue = false
+    private var dailyQueueStopRequested = false
+    private var stageAPCosts: [String: Int]?
+
     @Published private(set) var status = Status.idle
 
     private var wakeupAssertionID: UInt32?
@@ -72,6 +84,10 @@ import SwiftUI
             .appendingPathExtension("plist")
     }
 
+    var depotURL: URL {
+        Self.userDirectory.appendingPathComponent("depot-cache.plist", isDirectory: false)
+    }
+
     @AppStorage("MAAScheduledDailyTaskTimer") var serializedScheduledDailyTaskTimers: String?
 
     struct DailyTaskTimer: Codable {
@@ -88,14 +104,22 @@ import SwiftUI
     @Published private var stageActivities = [String: MAAStageActivity]()
 
     var stageActivity: MAAStageActivity? {
-        stageActivities[clientChannel.rawValue]
+        let channel = clientChannel == .Bilibili ? MAAClientChannel.Official : clientChannel
+        return stageActivities[channel.rawValue]
     }
 
     // MARK: - Recognition
 
     @Published var recruitConfig = RecruitConfiguration.recognition
     @Published var recruit: MAARecruit?
-    @Published var depot: MAADepot?
+    @Published var depot: MAADepot? {
+        didSet {
+            guard depot?.done == true, let depot,
+                let data = try? PropertyListEncoder().encode(depot)
+            else { return }
+            try? data.write(to: depotURL, options: .atomic)
+        }
+    }
     @Published var videoRecoginition: URL?
     @Published var operBox: MAAOperBox?
 
@@ -145,6 +169,10 @@ import SwiftUI
     // MARK: - Initializer
 
     init() {
+        if let data = try? Data(contentsOf: depotURL) {
+            depot = try? PropertyListDecoder().decode(MAADepot.self, from: data)
+        }
+
         do {
             let data = try Data(contentsOf: tasksURL)
             tasks = try PropertyListDecoder().decode([DailyTask].self, from: data)
@@ -243,6 +271,7 @@ extension MAAViewModel {
         status = .pending
         defer { handleEarlyReturn(backTo: .busy) }
 
+        dailyQueueStopRequested = true
         try await handle?.stop()
         status = .idle
     }
@@ -251,6 +280,8 @@ extension MAAViewModel {
         status = .idle
         medicineUsedTimes = 0
         expiringMedicineUsedTimes = 0
+        sanityReport = nil
+        provenExhaustedMedicineDays = 0
     }
 
     func screenshot() async throws -> NSImage {
@@ -434,6 +465,12 @@ extension MAAViewModel {
         status = .pending
         defer { handleEarlyReturn(backTo: .idle) }
 
+        dailyQueueStopRequested = false
+        medicineUsedTimes = 0
+        expiringMedicineUsedTimes = 0
+        sanityReport = nil
+        provenExhaustedMedicineDays = 0
+
         var firstStart = true
         for (index, task) in tasks.enumerated() {
             guard case .startup(var config) = task.task else {
@@ -462,6 +499,17 @@ extension MAAViewModel {
 
         try await ensureHandle()
 
+        let containsDepotMaintain = tasks.contains { task in
+            guard task.enabled else { return false }
+            if case .depotMaintain = task.task { return true }
+            return false
+        }
+
+        if containsDepotMaintain {
+            try await startTasksSequentially()
+            return
+        }
+
         for task in tasks {
             guard task.enabled else { continue }
 
@@ -473,6 +521,226 @@ extension MAAViewModel {
         try await handle?.start()
 
         status = .busy
+    }
+
+    private func startTasksSequentially() async throws {
+        isExecutingDailyQueue = true
+        defer {
+            isExecutingDailyQueue = false
+            if status != .idle {
+                resetStatus()
+            }
+        }
+
+        for task in tasks where task.enabled {
+            guard !dailyQueueStopRequested else { break }
+
+            switch task.task {
+            case .depotMaintain(let config):
+                try await runDepotMaintain(config, taskID: task.id)
+            default:
+                guard let coreID = try await handle?.appendTask(task.task) else { continue }
+                taskIDMap[coreID] = task.id
+                _ = try await runAppendedTask(parentID: task.id)
+            }
+        }
+
+        if !dailyQueueStopRequested {
+            logTrace("AllTasksComplete")
+        }
+    }
+
+    private func runDepotMaintain(_ config: DepotMaintainConfiguration, taskID: UUID) async throws {
+        let now = Date()
+        let activities = stageActivity?.fightScheduleData
+
+        if config.skipDuringActivity, activities?.hasActiveSideStory(at: now) == true {
+            taskStatus[taskID] = .success
+            logInfo("当前有活动进行中，已跳过库存保持。")
+            return
+        }
+
+        if config.skipDuringResourceCollection, activities?.resourceCollection?.contains(now) == true {
+            taskStatus[taskID] = .success
+            logInfo("当前处于资源收集限时全天开放期间，已跳过库存保持。")
+            return
+        }
+
+        var hadFailure = false
+
+        if config.updateDepot {
+            do {
+                guard let coreID = try await handle?.appendTask(type: .Depot, params: "") else {
+                    throw MaaCoreError.appendTaskFailed
+                }
+                taskIDMap[coreID] = taskID
+                let result = try await runAppendedTask(parentID: taskID)
+                hadFailure = result == .failure
+                if result == .failure {
+                    logError("库存更新失败，将继续使用缓存数据。")
+                }
+            } catch {
+                hadFailure = true
+                logError("库存更新失败，将继续使用缓存数据。")
+            }
+        }
+
+        let schedule = FightStageSchedule()
+        for (offset, plan) in config.plans.enumerated() {
+            guard !dailyQueueStopRequested else { break }
+            let index = offset + 1
+
+            guard !plan.stage.isEmpty else {
+                hadFailure = true
+                logError("库存保持计划 \(index) 未选择关卡，已跳过。")
+                continue
+            }
+            guard !plan.dropID.isEmpty else {
+                hadFailure = true
+                logError("库存保持计划 \(index) 未选择掉落物，已跳过。")
+                continue
+            }
+            guard plan.target > 0 else {
+                hadFailure = true
+                logError("库存保持计划 \(index) 的目标库存必须大于 0，已跳过。")
+                continue
+            }
+
+            let current = depot?.count(of: plan.dropID) ?? 0
+            let need = plan.target - current
+            if need <= 0 {
+                logInfo("库存保持计划 \(index) 已达标（\(current)/\(plan.target)），已跳过。")
+                continue
+            }
+
+            guard
+                schedule.isOpen(
+                    plan.stage,
+                    server: clientChannel.fightStageServer,
+                    activities: activities,
+                    at: Date())
+            else {
+                logInfo("库存保持计划 \(index) 的关卡 \(plan.stage) 今日未开放，已跳过。")
+                continue
+            }
+
+            let medicine = config.enableMedicine && plan.useMedicine ? max(0, plan.medicineCount) : 0
+            let stone = config.enableStone && plan.useStone ? max(0, plan.stoneCount) : 0
+            if shouldSkipForInsufficientSanity(
+                stage: plan.stage,
+                medicine: medicine,
+                stone: stone,
+                useExpiringMedicine: config.useExpiringMedicine)
+            {
+                let estimated = estimatedSanity() ?? 0
+                let cost = apCost(for: plan.stage) ?? 0
+                logInfo("库存保持计划 \(index) 预估理智不足（\(estimated)/\(cost)），已跳过。")
+                continue
+            }
+
+            let params = DepotMaintainFightParameters(
+                stage: plan.stage,
+                medicine: medicine,
+                medicineExpireDays: config.useExpiringMedicine ? 2 : 0,
+                stone: stone,
+                times: Int(Int32.max),
+                series: config.useAutoSeries ? 0 : 1,
+                drops: [plan.dropID: need],
+                server: penguinServer,
+                clientType: clientChannel.rawValue)
+
+            logInfo("库存保持计划 \(index) 开始：当前 \(current)，目标 \(plan.target)，缺口 \(need)。")
+            do {
+                let coreID = try await handle?.appendTask(type: .Fight, params: params.jsonString())
+                guard let coreID else { throw MaaCoreError.appendTaskFailed }
+                taskIDMap[coreID] = taskID
+                let result = try await runAppendedTask(parentID: taskID)
+                if result == .failure { hadFailure = true }
+
+                if result == .success,
+                    config.useExpiringMedicine,
+                    (depot?.count(of: plan.dropID) ?? 0) < plan.target
+                {
+                    provenExhaustedMedicineDays = max(provenExhaustedMedicineDays, 2)
+                }
+            } catch {
+                hadFailure = true
+                logError("库存保持计划 \(index) 添加作战任务失败。")
+            }
+        }
+
+        if dailyQueueStopRequested {
+            taskStatus[taskID] = .cancel
+        } else {
+            taskStatus[taskID] = hadFailure ? .failure : .success
+        }
+    }
+
+    private func runAppendedTask(parentID: UUID) async throws -> TaskStatus {
+        taskStatus[parentID] = .running
+        try await handle?.start()
+        status = .busy
+
+        while await handle?.running == true {
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        for _ in 0..<20 where taskStatus[parentID] == .running {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return taskStatus[parentID] ?? .failure
+    }
+
+    private func shouldSkipForInsufficientSanity(
+        stage: String,
+        medicine: Int,
+        stone: Int,
+        useExpiringMedicine: Bool
+    ) -> Bool {
+        guard medicine <= 0, stone <= 0,
+            !useExpiringMedicine || provenExhaustedMedicineDays >= 2,
+            let estimated = estimatedSanity(),
+            let cost = apCost(for: stage)
+        else { return false }
+        return estimated < cost
+    }
+
+    private func estimatedSanity(at date: Date = Date()) -> Int? {
+        guard let report = sanityReport else { return nil }
+        let elapsed = max(0, date.timeIntervalSince(report.reportedAt))
+        let regeneration = report.current < report.maximum ? Int(ceil(elapsed / 360)) : 0
+        return min(report.current + regeneration, report.maximum)
+    }
+
+    private func apCost(for stage: String) -> Int? {
+        if stageAPCosts == nil {
+            struct StageRecord: Decodable {
+                let code: String
+                let apCost: Int
+            }
+
+            let external = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+                .appendingPathComponent("resource/stages.json")
+            let bundled = Bundle.main.resourceURL!.appendingPathComponent("resource/stages.json")
+            let url = FileManager.default.fileExists(atPath: external.path) ? external : bundled
+            let records = (try? Data(contentsOf: url)).flatMap {
+                try? JSONDecoder().decode([StageRecord].self, from: $0)
+            }
+            stageAPCosts = Dictionary(
+                (records ?? []).map { ($0.code, $0.apCost) },
+                uniquingKeysWith: { first, _ in first })
+        }
+        return stageAPCosts?[stage]
+    }
+
+    private var penguinServer: String {
+        switch clientChannel {
+        case .Official, .Bilibili: "CN"
+        case .YoStarEN: "US"
+        case .YoStarJP: "JP"
+        case .YoStarKR: "KR"
+        case .txwy: "TW"
+        }
     }
 
     private func initScheduledDailyTaskTimer() {

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -38,6 +38,7 @@ import SwiftUI
     var isExecutingDailyQueue = false
     private var dailyQueueStopRequested = false
     private var stageAPCosts: [String: Int]?
+    var legacyStageDropItemIDsByName: [String: String]?
 
     @Published private(set) var status = Status.idle
 
@@ -589,8 +590,9 @@ extension MAAViewModel {
         for (offset, plan) in config.plans.enumerated() {
             guard !dailyQueueStopRequested else { break }
             let index = offset + 1
+            let stage = FightStageSchedule.normalizedStage(plan.stage)
 
-            guard !plan.stage.isEmpty else {
+            guard !stage.isEmpty else {
                 hadFailure = true
                 logError("库存保持计划 \(index) 未选择关卡，已跳过。")
                 continue
@@ -605,6 +607,11 @@ extension MAAViewModel {
                 logError("库存保持计划 \(index) 的目标库存必须大于 0，已跳过。")
                 continue
             }
+            guard let stageAPCost = apCost(for: stage) else {
+                hadFailure = true
+                logError("库存保持计划 \(index) 的关卡 \(stage) 无效或缺少理智消耗数据，已跳过。")
+                continue
+            }
 
             let current = depot?.count(of: plan.dropID) ?? 0
             let need = plan.target - current
@@ -615,31 +622,30 @@ extension MAAViewModel {
 
             guard
                 schedule.isOpen(
-                    plan.stage,
+                    stage,
                     server: clientChannel.fightStageServer,
                     activities: activities,
                     at: Date())
             else {
-                logInfo("库存保持计划 \(index) 的关卡 \(plan.stage) 今日未开放，已跳过。")
+                logInfo("库存保持计划 \(index) 的关卡 \(stage) 今日未开放，已跳过。")
                 continue
             }
 
             let medicine = config.enableMedicine && plan.useMedicine ? max(0, plan.medicineCount) : 0
             let stone = config.enableStone && plan.useStone ? max(0, plan.stoneCount) : 0
             if shouldSkipForInsufficientSanity(
-                stage: plan.stage,
+                cost: stageAPCost,
                 medicine: medicine,
                 stone: stone,
                 useExpiringMedicine: config.useExpiringMedicine)
             {
                 let estimated = estimatedSanity() ?? 0
-                let cost = apCost(for: plan.stage) ?? 0
-                logInfo("库存保持计划 \(index) 预估理智不足（\(estimated)/\(cost)），已跳过。")
+                logInfo("库存保持计划 \(index) 预估理智不足（\(estimated)/\(stageAPCost)），已跳过。")
                 continue
             }
 
             let params = DepotMaintainFightParameters(
-                stage: plan.stage,
+                stage: stage,
                 medicine: medicine,
                 medicineExpireDays: config.useExpiringMedicine ? 2 : 0,
                 stone: stone,
@@ -692,15 +698,14 @@ extension MAAViewModel {
     }
 
     private func shouldSkipForInsufficientSanity(
-        stage: String,
+        cost: Int,
         medicine: Int,
         stone: Int,
         useExpiringMedicine: Bool
     ) -> Bool {
         guard medicine <= 0, stone <= 0,
             !useExpiringMedicine || provenExhaustedMedicineDays >= 2,
-            let estimated = estimatedSanity(),
-            let cost = apCost(for: stage)
+            let estimated = estimatedSanity()
         else { return false }
         return estimated < cost
     }
@@ -708,7 +713,7 @@ extension MAAViewModel {
     private func estimatedSanity(at date: Date = Date()) -> Int? {
         guard let report = sanityReport else { return nil }
         let elapsed = max(0, date.timeIntervalSince(report.reportedAt))
-        let regeneration = report.current < report.maximum ? Int(ceil(elapsed / 360)) : 0
+        let regeneration = report.current < report.maximum ? Int(floor(elapsed / 360)) : 0
         return min(report.current + regeneration, report.maximum)
     }
 
@@ -727,10 +732,10 @@ extension MAAViewModel {
                 try? JSONDecoder().decode([StageRecord].self, from: $0)
             }
             stageAPCosts = Dictionary(
-                (records ?? []).map { ($0.code, $0.apCost) },
+                (records ?? []).map { (FightStageSchedule.normalizedStage($0.code), $0.apCost) },
                 uniquingKeysWith: { first, _ in first })
         }
-        return stageAPCosts?[stage]
+        return stageAPCosts?[FightStageSchedule.normalizedStage(stage)]
     }
 
     private var penguinServer: String {

--- a/MeoAsstMac/Navigation/TaskDetail.swift
+++ b/MeoAsstMac/Navigation/TaskDetail.swift
@@ -25,6 +25,8 @@ struct TaskDetail: View {
                         InfrastSettingsView(config: taskConfigBinding(config, id: id))
                     case .fight(let config):
                         FightSettingsView(config: taskConfigBinding(config, id: id))
+                    case .depotMaintain(let config):
+                        DepotMaintainSettingsView(config: taskConfigBinding(config, id: id))
                     case .mall(let config):
                         MallSettingsView(config: taskConfigBinding(config, id: id))
                     case .award(let config):

--- a/MeoAsstMac/Navigation/TasksContent.swift
+++ b/MeoAsstMac/Navigation/TasksContent.swift
@@ -25,6 +25,8 @@ struct TasksContent: View {
                     TaskCell(id: task.id, config: config, enabled: $task.enabled)
                 case .fight(let config):
                     TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                case .depotMaintain(let config):
+                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
                 case .mall(let config):
                     TaskCell(id: task.id, config: config, enabled: $task.enabled)
                 case .award(let config):

--- a/MeoAsstMac/Task Configurations/DepotMaintainConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/DepotMaintainConfiguration.swift
@@ -1,0 +1,171 @@
+//
+//  DepotMaintainConfiguration.swift
+//  MAA
+//
+
+import Foundation
+
+struct DepotMaintainConfiguration: MAATaskConfiguration {
+    var type: MAATaskType { .DepotMaintain }
+
+    var plans: [Plan]
+    var updateDepot: Bool
+    var useAutoSeries: Bool
+    var enableMedicine: Bool
+    var enableStone: Bool
+    var useExpiringMedicine: Bool
+    var skipDuringActivity: Bool
+    var skipDuringResourceCollection: Bool
+
+    var title: String { String(localized: "库存保持") }
+
+    var subtitle: String {
+        String(localized: "\(plans.count) 条计划")
+    }
+
+    var summary: String {
+        plans.prefix(2).map(\.stage).filter { !$0.isEmpty }.joined(separator: ", ")
+    }
+
+    var projectedTask: MAATask { .depotMaintain(self) }
+
+    typealias Params = Self
+    var params: Self { self }
+
+    struct Plan: Codable, Hashable, Identifiable {
+        var id: UUID
+        var stage: String
+        var dropID: String
+        var target: Int
+        var useMedicine: Bool
+        var medicineCount: Int
+        var useStone: Bool
+        var stoneCount: Int
+
+        init(
+            id: UUID = UUID(),
+            stage: String = "",
+            dropID: String = "",
+            target: Int = 0,
+            useMedicine: Bool = false,
+            medicineCount: Int = 0,
+            useStone: Bool = false,
+            stoneCount: Int = 0
+        ) {
+            self.id = id
+            self.stage = stage
+            self.dropID = dropID
+            self.target = target
+            self.useMedicine = useMedicine
+            self.medicineCount = medicineCount
+            self.useStone = useStone
+            self.stoneCount = stoneCount
+        }
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+            stage = try container.decodeIfPresent(String.self, forKey: .stage) ?? ""
+            dropID = try container.decodeIfPresent(String.self, forKey: .dropID) ?? ""
+            target = try container.decodeIfPresent(Int.self, forKey: .target) ?? 0
+            useMedicine = try container.decodeIfPresent(Bool.self, forKey: .useMedicine) ?? false
+            medicineCount = try container.decodeIfPresent(Int.self, forKey: .medicineCount) ?? 0
+            useStone = try container.decodeIfPresent(Bool.self, forKey: .useStone) ?? false
+            stoneCount = try container.decodeIfPresent(Int.self, forKey: .stoneCount) ?? 0
+        }
+    }
+}
+
+extension DepotMaintainConfiguration {
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        plans = try container.decodeIfPresent([Plan].self, forKey: .plans) ?? []
+        updateDepot = try container.decodeIfPresent(Bool.self, forKey: .updateDepot) ?? true
+        useAutoSeries = try container.decodeIfPresent(Bool.self, forKey: .useAutoSeries) ?? false
+        enableMedicine = try container.decodeIfPresent(Bool.self, forKey: .enableMedicine) ?? true
+        enableStone = try container.decodeIfPresent(Bool.self, forKey: .enableStone) ?? true
+        useExpiringMedicine = try container.decodeIfPresent(Bool.self, forKey: .useExpiringMedicine) ?? false
+        skipDuringActivity = try container.decodeIfPresent(Bool.self, forKey: .skipDuringActivity) ?? false
+        skipDuringResourceCollection =
+            try container.decodeIfPresent(Bool.self, forKey: .skipDuringResourceCollection) ?? false
+    }
+}
+
+extension DepotMaintainConfiguration {
+    enum Preset: String, CaseIterable, Identifiable {
+        case chip1
+        case chip2
+        case lmd
+        case certificate
+        case skillSummary
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .chip1: String(localized: "低级芯片（全职业）")
+            case .chip2: String(localized: "高级芯片组（全职业）")
+            case .lmd: String(localized: "龙门币")
+            case .certificate: String(localized: "采购凭证（红票）")
+            case .skillSummary: String(localized: "技巧概要·卷3")
+            }
+        }
+
+        var plans: [Plan] {
+            switch self {
+            case .chip1:
+                return Self.chipPlans(level: 1, target: 20)
+            case .chip2:
+                return Self.chipPlans(level: 2, target: 20)
+            case .lmd:
+                return [.init(stage: "CE-6", dropID: "4001", target: 2_000_000)]
+            case .certificate:
+                return [.init(stage: "AP-5", dropID: "4006", target: 5_000)]
+            case .skillSummary:
+                return [.init(stage: "CA-5", dropID: "3303", target: 200)]
+            }
+        }
+
+        private static func chipPlans(level: Int, target: Int) -> [Plan] {
+            let entries: [(String, [String])] = [
+                ("PR-A-\(level)", level == 1 ? ["3261", "3231"] : ["3262", "3232"]),
+                ("PR-B-\(level)", level == 1 ? ["3251", "3241"] : ["3252", "3242"]),
+                ("PR-C-\(level)", level == 1 ? ["3211", "3271"] : ["3212", "3272"]),
+                ("PR-D-\(level)", level == 1 ? ["3221", "3281"] : ["3222", "3282"]),
+            ]
+            return entries.flatMap { stage, drops in
+                drops.map { Plan(stage: stage, dropID: $0, target: target) }
+            }
+        }
+    }
+}
+
+struct DepotMaintainFightParameters: Encodable {
+    let stage: String
+    let medicine: Int
+    let medicineExpireDays: Int
+    let stone: Int
+    let times: Int
+    let series: Int
+    let drops: [String: Int]
+    let reportToPenguin = false
+    let penguinID = ""
+    let server: String
+    let clientType: String
+    let drGrandet = false
+
+    private enum CodingKeys: String, CodingKey {
+        case stage
+        case medicine
+        case medicineExpireDays = "medicine_expire_days"
+        case stone
+        case times
+        case series
+        case drops
+        case reportToPenguin = "report_to_penguin"
+        case penguinID = "penguin_id"
+        case server
+        case clientType = "client_type"
+        case drGrandet = "DrGrandet"
+    }
+}

--- a/MeoAsstMac/Task Configurations/MAATaskConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/MAATaskConfiguration.swift
@@ -43,6 +43,8 @@ extension MAAHandle {
             return try appendTask(config: config)
         case .fight(let config):
             return try appendTask(config: config)
+        case .depotMaintain:
+            throw MaaCoreError.uiOnlyTask
         case .mall(let config):
             return try appendTask(config: config)
         case .award(let config):


### PR DESCRIPTION
## 概要

在 MaaMacGui 中实现与 Windows 版语义一致的 UI 专属「库存保持」任务：根据仓库缓存逐条计算材料缺口，并将计划按执行时的最新库存展开为仓库识别与理智作战任务。

## 主要变更

- 新增可持久化的库存保持计划，支持拖拽排序、折叠、清空与五组内置预设
- 按 Windows 版区分「常规设置 / 高级设置」，支持每条计划独立配置药剂与源石预算
- 根据 `stages.json` 过滤关卡可掉落材料，并补齐 CE/AP 固定货币奖励；切换关卡时清除不匹配材料
- 可选在任务开始前执行仓库识别，并在每场战斗掉落后实时更新、持久化库存缓存
- 仅在队列包含库存保持时按任务顺序逐项执行，使前序掉落与剩余理智能影响后续计划
- 支持 AUTO 代理倍率、48 小时内临期药、活动期间跳过、资源收集全开放期间跳过
- 按服务器时区与 04:00 换日判断资源本/芯片本开放状态，并复用 `StageActivityV2.json` 活动窗口
- 根据最近一次战斗上报的理智值估算自然恢复，在无恢复预算且不足单次进图消耗时直接跳过计划
- 兼容 Core 新旧仓库回调格式，并让旧任务配置通过默认值平滑解码

## 实现说明

库存保持是 UI-only 任务，不会把不存在的 `DepotMaintain` 类型传给 Core；运行时会展开为现有的 `Depot` 和 `Fight` 任务。原有任务链在不包含库存保持时仍沿用原批量追加路径。

## 验证

- 基于最新 `origin/master` 独立分支实现，无额外历史提交
- 新增及相关 Swift 文件通过 `swift-format`，可独立检查的文件通过 strict lint
- `plutil -lint MeoAsstMac.xcodeproj/project.pbxproj`
- Debug arm64 构建：`BUILD SUCCEEDED`
- `git diff --check`

## Sourcery 总结

在 MaaMacGui 中实现与现有任务体系集成的 UI 专属库存保持功能。

新功能：
- 新增可持久化的“库存保持”任务配置，支持多计划排序、预设、材料目标及独立资源预算。
- 根据最新库存逐项展开仓库识别和理智作战任务，并支持活动跳过、关卡开放判断、AUTO 代理和理智恢复估算。

错误修复：
- 兼容新旧仓库数据格式，并为旧任务配置提供默认值解码。

功能增强：
- 持久化战斗掉落与库存缓存，使后续计划能够使用前序任务的最新库存。
- 扩展活动数据解析和资源关卡开放状态判断，并在包含库存保持任务时按顺序执行每日任务队列。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

实现仅限 UI 的库存维护任务，利用实时库存以及现有的仓库和战斗能力，按顺序维护材料目标。

新功能：
- 添加持久化的仅限 UI 的库存维护任务，支持可重新排序的计划、预设、材料目标以及每个计划的资源预算。
- 根据当前库存、关卡可用性、活动时间窗口和预估理智恢复情况，将库存维护计划展开为按顺序执行的仓库识别任务和理智刷取任务。

错误修复：
- 支持旧版仓库回调和库存格式，并使用安全默认值解码较旧的任务配置。

增强功能：
- 持久化库存和战斗掉落更新，使后续计划能够使用最新库存以及前序队列的执行结果。
- 支持感知服务器的资源关卡调度、活动处理、AUTO 刷取、即将过期的药剂，以及每日队列的顺序执行。

构建：
- 将新的库存维护源文件注册到 Xcode 项目中。

测试：
- 验证格式、项目文件语法、Debug arm64 编译以及空白字符一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement UI-only inventory maintenance tasks that sequentially maintain material targets using live inventory and existing depot and fight capabilities.

New Features:
- Add a persistent UI-only inventory maintenance task with reorderable plans, presets, material targets, and per-plan resource budgets.
- Expand inventory maintenance plans into sequential depot recognition and sanity farming tasks using current inventory, stage availability, activity windows, and estimated sanity recovery.

Bug Fixes:
- Support legacy depot callback and inventory formats and decode older task configurations with safe defaults.

Enhancements:
- Persist inventory and battle-drop updates so later plans use the latest stock and preceding queue results.
- Add server-aware resource-stage scheduling, activity handling, AUTO farming, expiring medicine support, and sequential daily-queue execution.

Build:
- Register the new inventory maintenance source files in the Xcode project.

Tests:
- Validate formatting, project-file syntax, Debug arm64 compilation, and whitespace consistency.

</details>

</details>