### PR TITLE
fix(mac): fall back when user resources are incompatible

### DIFF
--- a/MeoAsstMac/Core/Maa.swift
+++ b/MeoAsstMac/Core/Maa.swift
@@ -210,6 +210,31 @@ enum MaaCoreError: Error {
     case asyncCallFailed
 }
 
+extension MaaCoreError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .loadResourceFailed:
+            return "加载 MAA 资源失败，请检查资源版本或更新 MAA"
+        case .setUserDirectoryFailed:
+            return "设置 MAA 用户目录失败"
+        case .setInstanceOptionFailed:
+            return "设置 MAA 实例选项失败"
+        case .appendTaskFailed:
+            return "添加 MAA 任务失败"
+        case .startFailed:
+            return "启动 MAA 任务失败"
+        case .stopFailed:
+            return "停止 MAA 任务失败"
+        case .connectFailed:
+            return "连接模拟器失败"
+        case .getImageFailed:
+            return "获取模拟器截图失败"
+        case .asyncCallFailed:
+            return "MAA 异步调用失败"
+        }
+    }
+}
+
 enum MAAInstanceOptionKey: Int32 {
     case Invalid = 0
     case TouchMode = 2

--- a/MeoAsstMac/Core/Maa.swift
+++ b/MeoAsstMac/Core/Maa.swift
@@ -214,23 +214,23 @@ extension MaaCoreError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .loadResourceFailed:
-            return "加载 MAA 资源失败，请检查资源版本或更新 MAA"
+            return String(localized: "MaaCoreLoadResourceFailed")
         case .setUserDirectoryFailed:
-            return "设置 MAA 用户目录失败"
+            return String(localized: "MaaCoreSetUserDirectoryFailed")
         case .setInstanceOptionFailed:
-            return "设置 MAA 实例选项失败"
+            return String(localized: "MaaCoreSetInstanceOptionFailed")
         case .appendTaskFailed:
-            return "添加 MAA 任务失败"
+            return String(localized: "MaaCoreAppendTaskFailed")
         case .startFailed:
-            return "启动 MAA 任务失败"
+            return String(localized: "MaaCoreStartFailed")
         case .stopFailed:
-            return "停止 MAA 任务失败"
+            return String(localized: "MaaCoreStopFailed")
         case .connectFailed:
-            return "连接模拟器失败"
+            return String(localized: "MaaCoreConnectFailed")
         case .getImageFailed:
-            return "获取模拟器截图失败"
+            return String(localized: "MaaCoreGetImageFailed")
         case .asyncCallFailed:
-            return "MAA 异步调用失败"
+            return String(localized: "MaaCoreAsyncCallFailed")
         }
     }
 }

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -263,8 +263,52 @@ extension MAAViewModel {
 
     /// Reloads the resources from the documents directory after update.
     func reloadResources(channel: MAAClientChannel) async throws {
+        try await loadUserResource(channel: channel)
+    }
+
+    /// Loads the user resource set and restores the bundled resources when it
+    /// is not compatible with the currently bundled MaaCore. Resource updates
+    /// are published independently from the app, so an older app can receive a
+    /// newer schema (for example, an `infrast.json` with fields unknown to its
+    /// core). Keeping the bad directory in place makes every launch fail with
+    /// the unhelpful `MaaCoreError 0`; quarantine it so the next launch can use
+    /// the known-good bundled resources while preserving the user's files.
+    private func loadUserResource(channel: MAAClientChannel) async throws {
         let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-        try await loadResource(url: documentsDirectory, channel: channel)
+
+        do {
+            try await loadResource(url: documentsDirectory, channel: channel)
+        } catch {
+            let resourceDirectory = documentsDirectory.appendingPathComponent("resource", isDirectory: true)
+            quarantineUserResource(at: resourceDirectory)
+
+            // The failed load may have partially replaced MaaCore's global
+            // state. Reload the bundled resources before propagating the
+            // original error to callers (the outer loader handles fallback).
+            do {
+                try await loadResource(url: Bundle.main.resourceURL!, channel: channel)
+            } catch {
+                logError("恢复内置资源失败: \(error.localizedDescription)")
+            }
+
+            throw error
+        }
+    }
+
+    private func quarantineUserResource(at resourceDirectory: URL) {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: resourceDirectory.path) else { return }
+
+        let suffix = UUID().uuidString.prefix(8)
+        let backupURL = resourceDirectory.deletingLastPathComponent()
+            .appendingPathComponent("resource.invalid-\(suffix)", isDirectory: true)
+
+        do {
+            try fileManager.moveItem(at: resourceDirectory, to: backupURL)
+            logError("外部资源与当前 MAA 版本不兼容，已备份至 \(backupURL.lastPathComponent)")
+        } catch {
+            logError("无法备份不兼容的外部资源: \(error.localizedDescription)")
+        }
     }
 
     /// Load base resources and channel-specific resources.
@@ -331,16 +375,25 @@ extension MAAViewModel {
     /// Should be the outermost call to load resources.
     private func loadResource(channel: MAAClientChannel) async throws {
         let (preferUser, currentResourceVersion) = try resourceChannel.version()
-        try await loadResource(url: Bundle.main.resourceURL!, channel: channel)
-
         let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let bundledResourceURL = Bundle.main.resourceURL!
+        try await loadResource(url: bundledResourceURL, channel: channel)
+
         if preferUser {
-            try await reloadResources(channel: channel)
-            logTrace(
-                """
-                外部资源版本：\(currentResourceVersion.title)
-                更新时间：\(currentResourceVersion.last_updated)
-                """)
+            do {
+                try await loadUserResource(channel: channel)
+                logTrace(
+                    """
+                    外部资源版本：\(currentResourceVersion.title)
+                    更新时间：\(currentResourceVersion.last_updated)
+                    """)
+            } catch {
+                // `loadUserResource` has already restored the bundled set and
+                // quarantined the incompatible external resources. Keep
+                // initialization usable instead of surfacing MaaCoreError 0.
+                logError("外部资源加载失败，已回退内置资源: \(error.localizedDescription)")
+                logTrace("已加载内置资源")
+            }
         } else {
             logTrace(
                 """

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -183,6 +183,11 @@ import SwiftUI
 
 // MARK: - MaaCore
 
+private enum MAAUserResourceLoadResult {
+    case loaded
+    case fellBackToBundled
+}
+
 extension MAAViewModel {
     func initialize() async throws {
         status = .pending
@@ -263,7 +268,10 @@ extension MAAViewModel {
 
     /// Reloads the resources from the documents directory after update.
     func reloadResources(channel: MAAClientChannel) async throws {
-        try await loadUserResource(channel: channel)
+        let result = try await loadUserResource(channel: channel)
+        if case .fellBackToBundled = result {
+            throw MaaCoreError.loadResourceFailed
+        }
     }
 
     /// Loads the user resource set and restores the bundled resources when it
@@ -273,25 +281,29 @@ extension MAAViewModel {
     /// core). Keeping the bad directory in place makes every launch fail with
     /// the unhelpful `MaaCoreError 0`; quarantine it so the next launch can use
     /// the known-good bundled resources while preserving the user's files.
-    private func loadUserResource(channel: MAAClientChannel) async throws {
+    private func loadUserResource(channel: MAAClientChannel) async throws -> MAAUserResourceLoadResult {
         let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
 
         do {
             try await loadResource(url: documentsDirectory, channel: channel)
+            return .loaded
         } catch {
+            let userResourceError = error
             let resourceDirectory = documentsDirectory.appendingPathComponent("resource", isDirectory: true)
             quarantineUserResource(at: resourceDirectory)
 
             // The failed load may have partially replaced MaaCore's global
-            // state. Reload the bundled resources before propagating the
-            // original error to callers (the outer loader handles fallback).
+            // state. Reload the bundled resources before reporting fallback
+            // success to callers.
             do {
                 try await loadResource(url: Bundle.main.resourceURL!, channel: channel)
             } catch {
                 logError("恢复内置资源失败: \(error.localizedDescription)")
+                throw error
             }
 
-            throw error
+            logError("外部资源加载失败，已回退内置资源: \(userResourceError.localizedDescription)")
+            return .fellBackToBundled
         }
     }
 
@@ -380,18 +392,14 @@ extension MAAViewModel {
         try await loadResource(url: bundledResourceURL, channel: channel)
 
         if preferUser {
-            do {
-                try await loadUserResource(channel: channel)
+            switch try await loadUserResource(channel: channel) {
+            case .loaded:
                 logTrace(
                     """
                     外部资源版本：\(currentResourceVersion.title)
                     更新时间：\(currentResourceVersion.last_updated)
                     """)
-            } catch {
-                // `loadUserResource` has already restored the bundled set and
-                // quarantined the incompatible external resources. Keep
-                // initialization usable instead of surfacing MaaCoreError 0.
-                logError("外部资源加载失败，已回退内置资源: \(error.localizedDescription)")
+            case .fellBackToBundled:
                 logTrace("已加载内置资源")
             }
         } else {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4928,6 +4928,150 @@
         }
       }
     },
+    "MaaCoreAppendTaskFailed" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MAA 작업을 추가하지 못했습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加 MAA 任务失败"
+          }
+        }
+      }
+    },
+    "MaaCoreAsyncCallFailed" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MAA 비동기 호출에 실패했습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MAA 异步调用失败"
+          }
+        }
+      }
+    },
+    "MaaCoreConnectFailed" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "에뮬레이터에 연결하지 못했습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接模拟器失败"
+          }
+        }
+      }
+    },
+    "MaaCoreGetImageFailed" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "에뮬레이터 스크린샷을 가져오지 못했습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "获取模拟器截图失败"
+          }
+        }
+      }
+    },
+    "MaaCoreLoadResourceFailed" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MAA 리소스를 불러오지 못했습니다. 리소스 버전을 확인하거나 MAA를 업데이트하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加载 MAA 资源失败，请检查资源版本或更新 MAA"
+          }
+        }
+      }
+    },
+    "MaaCoreSetInstanceOptionFailed" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MAA 인스턴스 옵션을 설정하지 못했습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置 MAA 实例选项失败"
+          }
+        }
+      }
+    },
+    "MaaCoreSetUserDirectoryFailed" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MAA 사용자 디렉터리를 설정하지 못했습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置 MAA 用户目录失败"
+          }
+        }
+      }
+    },
+    "MaaCoreStartFailed" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MAA 작업을 시작하지 못했습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启动 MAA 任务失败"
+          }
+        }
+      }
+    },
+    "MaaCoreStopFailed" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MAA 작업을 중지하지 못했습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止 MAA 任务失败"
+          }
+        }
+      }
+    },
     "黑流树海" : {
 
     },


### PR DESCRIPTION
## Summary

- Keep loading bundled resources first, then prefer a newer user resource set when it is compatible.
- If MaaCore rejects the user resource set (for example, after a resource schema update), quarantine it as `resource.invalid-*`, reload the bundled resources, and continue initialization.
- Preserve the failed resource set for recovery/debugging instead of deleting it.
- Provide localized descriptions for `MaaCoreError` values so unrecoverable failures are actionable.

## Why

MAA resources are updated independently from the macOS GUI and MaaCore. A newer `infrast.json` can contain fields or enum values that an older bundled core cannot parse. Previously this surfaced as `MaaCoreError 0` and prevented the app from starting on every launch.

## Validation

- `swiftc -parse MeoAsstMac/Model/MAAViewModel.swift MeoAsstMac/Core/Maa.swift`
- `git diff --check`
- Reproduced the incompatible external resource case locally and verified that the app starts with bundled resources after the external resource directory is quarantined.

A full `xcodebuild` was not available in the local environment because only Command Line Tools are installed; the upstream macOS CI should provide the full build verification.

## Sourcery 摘要

通过恢复捆绑资源，同时保留失败的资源集以便恢复，确保不兼容的用户资源不再阻止 macOS 应用初始化。

错误修复：
- 当不兼容的用户资源集阻止 MaaCore 加载时，回退到捆绑资源。
- 将不兼容的用户资源隔离到具有唯一名称的备份目录中，而不是删除它们。

增强功能：
- 为 MaaCore 错误添加本地化且可执行的描述。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过恢复捆绑资源，同时保留失败的资源集以便恢复，确保不兼容的用户资源不再阻止 macOS 应用初始化。

错误修复：
- 当不兼容的用户资源集阻止 MaaCore 加载时，回退到捆绑资源。
- 将不兼容的用户资源隔离到名称唯一的备份目录中，而不是直接删除。

增强功能：
- 为 MaaCore 错误添加本地化描述，使无法恢复的故障更易于采取相应措施。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure incompatible user resources no longer prevent macOS app initialization by restoring bundled resources while preserving the failed resource set for recovery.

Bug Fixes:
- Fall back to bundled resources when an incompatible user resource set prevents MaaCore from loading.
- Quarantine incompatible user resources under uniquely named backup directories instead of deleting them.

Enhancements:
- Add localized descriptions for MaaCore errors to make unrecoverable failures actionable.

</details>

</details>