### PR TITLE
feat: 边栏新增今日关卡小提示

### DIFF
--- a/MeoAsstMac.xcodeproj/project.pbxproj
+++ b/MeoAsstMac.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		92F78D4D2A0A7B2E00999BD0 /* TaskTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F78D4C2A0A7B2E00999BD0 /* TaskTimerView.swift */; };
 		92F78D4F2A0B361C00999BD0 /* TaskTimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F78D4E2A0B361C00999BD0 /* TaskTimerManager.swift */; };
 		9BC2EEB32E3F188D0039C4DB /* MiniGameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC2EEB22E3F188D0039C4DB /* MiniGameView.swift */; };
+		0A02E43EFA664077B621BA67 /* DailyStageTipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7516E8266D2E4719BDEF9267 /* DailyStageTipView.swift */; };
 		AEA8E3A02E77003F00355D84 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = AEA8E39F2E77003F00355D84 /* AppIcon.icon */; };
 /* End PBXBuildFile section */
 
@@ -237,6 +238,7 @@
 		92F78D4C2A0A7B2E00999BD0 /* TaskTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTimerView.swift; sourceTree = "<group>"; };
 		92F78D4E2A0B361C00999BD0 /* TaskTimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTimerManager.swift; sourceTree = "<group>"; };
 		9BC2EEB22E3F188D0039C4DB /* MiniGameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniGameView.swift; sourceTree = "<group>"; };
+		7516E8266D2E4719BDEF9267 /* DailyStageTipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyStageTipView.swift; sourceTree = "<group>"; };
 		AEA8E39F2E77003F00355D84 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -334,6 +336,7 @@
 				8347B5A72CDF85A000AEB627 /* ResourceUpdateView.swift */,
 				83985BC13026055400D2A789 /* FileTreeView.swift */,
 				831597113028DF98008C7EDF /* CapsulePicker.swift */,
+				7516E8266D2E4719BDEF9267 /* DailyStageTipView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -598,6 +601,7 @@
 				8341195329EC25A900044F45 /* MAALog.swift in Sources */,
 				83BFABC82AF1D5BA001A79F4 /* AwardSettingsView.swift in Sources */,
 				9BC2EEB32E3F188D0039C4DB /* MiniGameView.swift in Sources */,
+				0A02E43EFA664077B621BA67 /* DailyStageTipView.swift in Sources */,
 				832985BB29EFA26D009F7ED5 /* TaskDetail.swift in Sources */,
 				834DEC122C4D94BD0073B5D4 /* ClosedownConfiguration.swift in Sources */,
 				83477CB429FEA7A500A5FF99 /* TaskButtons.swift in Sources */,

--- a/MeoAsstMac/Navigation/Sidebar.swift
+++ b/MeoAsstMac/Navigation/Sidebar.swift
@@ -13,6 +13,9 @@ struct Sidebar: View {
     @Binding var showUpdate: Bool
     let onUpdate: () async throws -> Void
 
+    @EnvironmentObject private var viewModel: MAAViewModel
+    @State private var showStageTip = false
+
     @Environment(\.defaultMinListRowHeight) var rowHeight
 
     var body: some View {
@@ -24,6 +27,15 @@ struct Sidebar: View {
             VStack(alignment: .listRowSeparatorLeading, spacing: 12) {
                 Link(destination: URL(string: "https://docs.maa.plus/zh-cn/mac.html")!) {
                     Label("帮助与公告…", systemImage: "questionmark.circle")
+                }
+
+                Button {
+                    showStageTip.toggle()
+                } label: {
+                    Label("今日关卡…", systemImage: "calendar.day.timeline.left")
+                }
+                .popover(isPresented: $showStageTip, arrowEdge: .trailing) {
+                    DailyStageTipView(channel: viewModel.clientChannel)
                 }
 
                 Button {
@@ -58,6 +70,7 @@ struct SidebarView_Previews: PreviewProvider {
             Sidebar(selection: .constant(.daily), showUpdate: .constant(false)) {
                 print("Resource updated")
             }
+            .environmentObject(MAAViewModel())
         }
     }
 }

--- a/MeoAsstMac/Views/DailyStageTipView.swift
+++ b/MeoAsstMac/Views/DailyStageTipView.swift
@@ -1,0 +1,121 @@
+//
+//  DailyStageTipView.swift
+//  MAA
+//
+//  Created by zhangweijian on 1/9/2026.
+//
+
+import SwiftUI
+
+// MARK: - Daily stage tip
+
+/// 每日轮换资源关卡的开放提示。
+///
+/// 开放表与游戏内日历（yj 历）的换算参照 MaaWpfGui 的实现：
+/// 各服务器按当地时区的凌晨 4 点作为一天的开始。
+enum DailyStageTip {
+    enum Weekday: Int, CaseIterable {
+        case sunday = 1
+        case monday, tuesday, wednesday, thursday, friday, saturday
+
+        var localizedName: String {
+            switch self {
+            case .sunday: String(localized: "星期日")
+            case .monday: String(localized: "星期一")
+            case .tuesday: String(localized: "星期二")
+            case .wednesday: String(localized: "星期三")
+            case .thursday: String(localized: "星期四")
+            case .friday: String(localized: "星期五")
+            case .saturday: String(localized: "星期六")
+            }
+        }
+    }
+
+    struct Stage {
+        let code: String
+        let name: String
+        let weekdays: Set<Weekday>
+    }
+
+    /// 每日轮换关卡的开放日（游戏事实数据，与 MAAUnified 的开放表保持一致）
+    private static let stages: [Stage] = [
+        Stage(code: "CE-6", name: String(localized: "龙门币"), weekdays: [.tuesday, .thursday, .saturday, .sunday]),
+        Stage(code: "AP-5", name: String(localized: "红票"), weekdays: [.monday, .thursday, .saturday, .sunday]),
+        Stage(code: "CA-5", name: String(localized: "技能"), weekdays: [.tuesday, .wednesday, .friday, .sunday]),
+        Stage(code: "SK-5", name: String(localized: "碳"), weekdays: [.monday, .wednesday, .friday, .saturday]),
+        Stage(code: "LS-6", name: String(localized: "经验"), weekdays: Set(Weekday.allCases)),
+        Stage(code: "PR-A-1/2", name: String(localized: "奶&盾芯片"), weekdays: [.monday, .thursday, .friday, .sunday]),
+        Stage(code: "PR-B-1/2", name: String(localized: "术&狙芯片"), weekdays: [.monday, .tuesday, .friday, .saturday]),
+        Stage(code: "PR-C-1/2", name: String(localized: "先&辅芯片"), weekdays: [.wednesday, .thursday, .saturday, .sunday]),
+        Stage(code: "PR-D-1/2", name: String(localized: "近&特芯片"), weekdays: [.tuesday, .wednesday, .saturday, .sunday]),
+    ]
+
+    /// 各服务器的当地时区偏移（小时）
+    private static func utcOffset(channel: MAAClientChannel) -> Int {
+        switch channel {
+        case .Official, .Bilibili, .txwy: 8
+        case .YoStarEN: -7
+        case .YoStarJP, .YoStarKR: 9
+        }
+    }
+
+    /// 游戏内日历：当地时区减去凌晨 4 点的日切
+    private static func yjCalendar(channel: MAAClientChannel) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: (utcOffset(channel: channel) - 4) * 3600)!
+        return calendar
+    }
+
+    /// 游戏内日历（yj 历）下的今天星期几
+    static func yjWeekday(channel: MAAClientChannel, date: Date = .now) -> Weekday {
+        let calendar = yjCalendar(channel: channel)
+        return Weekday(rawValue: calendar.component(.weekday, from: date)) ?? .sunday
+    }
+
+    /// 今日开放的每日轮换关卡
+    static func openStages(channel: MAAClientChannel, date: Date = .now) -> [Stage] {
+        let weekday = yjWeekday(channel: channel, date: date)
+        return stages.filter { $0.weekdays.contains(weekday) }
+    }
+}
+
+// MARK: - View
+
+struct DailyStageTipView: View {
+    let channel: MAAClientChannel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("今日关卡小提示")
+                .font(.headline)
+
+            Text(String(localized: "游戏内历法：\(weekdayName)"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            ForEach(openStages, id: \.code) { stage in
+                Text(verbatim: "\(stage.code): \(stage.name)")
+                    .font(.callout)
+            }
+        }
+        .padding(12)
+        .frame(width: 240, alignment: .leading)
+    }
+
+    private var openStages: [DailyStageTip.Stage] {
+        DailyStageTip.openStages(channel: channel)
+    }
+
+    private var weekdayName: String {
+        DailyStageTip.yjWeekday(channel: channel).localizedName
+    }
+}
+
+struct DailyStageTipView_Previews: PreviewProvider {
+    static var previews: some View {
+        DailyStageTipView(channel: .Official)
+            .environment(\.locale, Locale(identifier: "zh-Hans"))
+    }
+}

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,6 +1,196 @@
 {
   "sourceLanguage" : "zh-Hans",
   "strings" : {
+    "今日关卡…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today's Stages…"
+          }
+        }
+      }
+    },
+    "今日关卡小提示" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today's open stages"
+          }
+        }
+      }
+    },
+    "游戏内历法：%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In-game calendar: %@"
+          }
+        }
+      }
+    },
+    "星期日" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sunday"
+          }
+        }
+      }
+    },
+    "星期一" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monday"
+          }
+        }
+      }
+    },
+    "星期二" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tuesday"
+          }
+        }
+      }
+    },
+    "星期三" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wednesday"
+          }
+        }
+      }
+    },
+    "星期四" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thursday"
+          }
+        }
+      }
+    },
+    "星期五" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Friday"
+          }
+        }
+      }
+    },
+    "星期六" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saturday"
+          }
+        }
+      }
+    },
+    "龙门币" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LMD"
+          }
+        }
+      }
+    },
+    "红票" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Purchase Certificate"
+          }
+        }
+      }
+    },
+    "技能" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skill Summary"
+          }
+        }
+      }
+    },
+    "碳" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carbon"
+          }
+        }
+      }
+    },
+    "经验" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Battle Record"
+          }
+        }
+      }
+    },
+    "奶&盾芯片" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Med&Def Chip"
+          }
+        }
+      }
+    },
+    "术&狙芯片" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cst&Sni Chip"
+          }
+        }
+      }
+    },
+    "先&辅芯片" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pio&Sup Chip"
+          }
+        }
+      }
+    },
+    "近&特芯片" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grd&Spc Chip"
+          }
+        }
+      }
+    },
     "" : {
       "shouldTranslate" : false
     },


### PR DESCRIPTION
## 功能

在边栏底部按钮区新增「今日关卡…」按钮，点击弹出 popover，展示每日轮换资源关卡（CE/AP/CA/SK/LS/PR 系列）的今日开放列表。

![今日关卡小提示](https://raw.githubusercontent.com/zhangweijian97/MaaMacGui/screenshots/maa-stage-tip.jpg)

## 背景

WpfGui 与 MAAUnified 均有「今日关卡小提示」，MacGui 缺失。

## 设计说明

MacGui 的三栏布局中，这条信息不属于任务列表、任务配置或日志任何一个容器，也不适合常驻占据内容区。故参照边栏底部「资源更新…」的既有模式，做成独立入口 + popover（纯查看，点外部即关闭）。

## 实现

- 开放表与游戏内日历（yj 历）换算参照 MaaWpfGui：各服务器按当地时区凌晨 4 点为一天之始（官服系 +8 / 国际服 -7 / 日韩服 +9）
- 顶部显示游戏内历法的星期几，方便对齐自然日与游戏日的错位
- 开放表数据与 MAAUnified 的 WeeklyOpenStageCodes 保持一致

## 备注

- 本地基于最新 master（2ec69b0）rebase 后构建通过。构建时发现 master 上 NewViewModel.swift 的 Task.detached(name:) 在 macOS 26 SDK + deployment target 14.0 下需要 #available 检查才能编译，供参考
- 韩语翻译未补（关卡术语译名不确定），欢迎补充

## Sourcery 摘要

添加一个侧边栏弹出窗口，用于查看每日轮换资源关卡。

新功能：
- 添加一个侧边栏入口，打开弹出窗口，显示 CE、AP、CA、SK、LS 和 PR 类别中今天可用的轮换资源关卡。
- 显示游戏内星期几，并根据所选服务器频道对关卡名称进行本地化。

改进：
- 根据游戏凌晨 4 点的日期边界和各服务器特定的时区，调整每日关卡的可用时间。

构建：
- 在 Xcode 项目中注册新的每日关卡提示视图。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

添加一个侧边栏弹出窗口，用于显示所选服务器频道当天可用的轮换资源关卡。

新功能：
- 添加侧边栏入口和弹出窗口，用于查看 CE、AP、CA、SK、LS 和 PR 类别中当天可用的轮换资源关卡。

增强功能：
- 根据游戏内星期几、配置的服务器特定时区以及凌晨 4 点的日期边界，计算关卡可用性。
- 为受支持的频道本地化关卡提示中的标签、星期显示和关卡名称。

构建：
- 在 Xcode 项目中注册新的每日关卡提示视图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a sidebar popover that shows the rotating resource stages available today for the selected server channel.

New Features:
- Add a sidebar entry and popover for viewing today’s available rotating resource stages across CE, AP, CA, SK, LS, and PR categories.

Enhancements:
- Calculate stage availability using the in-game weekday and the configured server-specific timezone and 4 a.m. day boundary.
- Localize the stage tip’s labels, weekday display, and stage names for supported channels.

Build:
- Register the new daily stage tip view in the Xcode project.

</details>

</details>