### PR TITLE
feat: 干员列表支持导出 JSON（剪贴板/文件，格式与 Windows 一致）

### DIFF
--- a/MeoAsstMac/Model/MAAOperBox.swift
+++ b/MeoAsstMac/Model/MAAOperBox.swift
@@ -63,3 +63,93 @@ extension MAAOperBox.OwnedOper {
         }
     }
 }
+
+// MARK: - Export
+
+extension MAAOperBox {
+    /// 与 Windows 版“干员列表 JSON 导出”单条记录同构，键序即 Json.NET 的输出顺序。
+    struct ExportItem: Hashable {
+        let id: String
+        let name: String
+        let elite: Int
+        let level: Int
+        let own: Bool
+        let potential: Int
+        let rarity: Int
+    }
+
+    /// 与 Windows `DataHelper._virtualOperators` 对齐的未实装/试用干员 charId，
+    /// 这些干员不出现在导出 JSON 中（Windows 遍历其全量干员表时本就轮不到它们）。
+    private static let excludedExportIDs: Set<String> = [
+        "char_504_rguard", "char_505_rcast", "char_506_rmedic", "char_507_rsnipe",
+        "char_508_aguard", "char_509_acast", "char_510_amedic", "char_511_asnipe",
+        "char_512_aprot", "char_513_apionr", "char_514_rdfend",
+        "char_600_cpione", "char_601_cguard", "char_602_cdfend", "char_603_csnipe",
+        "char_604_ccast", "char_605_cmedic", "char_606_csuppo", "char_607_cspec",
+        "char_608_acpion", "char_609_acguad", "char_610_acfend", "char_611_acnipe",
+        "char_612_accast", "char_613_acmedc", "char_614_acsupo", "char_615_acspec",
+        "char_616_pithst", "char_617_sharp2",
+        "char_1001_amiya2", "char_1037_amiya3",
+    ]
+
+    /// 以 `all_opers` 为全量（保持其顺序），按 `id` 合并 `own_opers` 的精装/等级/潜能。
+    /// 未匹配到的干员按未拥有导出（`elite/level/potential` 为 0，`own` 为 false）。
+    /// 只输出 `all_opers` 中存在且非 `excludedExportIDs` 的干员，与 Windows 遍历其全量干员表的语义一致。
+    var exportItems: [ExportItem] {
+        let ownByID = Dictionary(own_opers.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        return all_opers
+            .filter { !Self.excludedExportIDs.contains($0.id) }
+            .map { oper in
+            let owned = ownByID[oper.id]
+            return ExportItem(
+                id: oper.id,
+                name: oper.name,
+                elite: owned?.elite ?? 0,
+                level: owned?.level ?? 0,
+                own: owned?.own ?? false,
+                potential: owned?.potential ?? 0,
+                rarity: oper.rarity)
+        }
+    }
+
+    /// 缩进 JSON（UTF-8、无 BOM），剪贴板与文件正文共用此内容。
+    /// JSONEncoder 不保证键序，故手写序列化以匹配 Windows 的 `id,name,elite,level,own,potential,rarity` 顺序与 2 空格缩进。
+    var exportJSONData: Data? {
+        var lines = ["["]
+        for (index, item) in exportItems.enumerated() {
+            let objectComma = index < exportItems.count - 1 ? "," : ""
+            lines.append("  {")
+            lines.append("    \"id\": \(Self.jsonString(item.id)),")
+            lines.append("    \"name\": \(Self.jsonString(item.name)),")
+            lines.append("    \"elite\": \(item.elite),")
+            lines.append("    \"level\": \(item.level),")
+            lines.append("    \"own\": \(item.own ? "true" : "false"),")
+            lines.append("    \"potential\": \(item.potential),")
+            lines.append("    \"rarity\": \(item.rarity)")
+            lines.append("  }" + objectComma)
+        }
+        lines.append("]")
+        return lines.joined(separator: "\n").data(using: .utf8)
+    }
+
+    private static func jsonString(_ value: String) -> String {
+        var escaped = "\""
+        for scalar in value.unicodeScalars {
+            switch scalar.value {
+            case 0x22: escaped += "\\\"" // "
+            case 0x5C: escaped += "\\\\" // 反斜杠
+            case 0x08: escaped += "\\b"
+            case 0x0C: escaped += "\\f"
+            case 0x0A: escaped += "\\n"
+            case 0x0D: escaped += "\\r"
+            case 0x09: escaped += "\\t"
+            case 0x00...0x1F:
+                escaped += String(format: "\\u%04X", scalar.value)
+            default:
+                escaped.unicodeScalars.append(scalar)
+            }
+        }
+        escaped += "\""
+        return escaped
+    }
+}

--- a/MeoAsstMac/Views/OperBoxView.swift
+++ b/MeoAsstMac/Views/OperBoxView.swift
@@ -5,31 +5,53 @@
 //  Created by hguandl on 22/4/2023.
 //
 
+import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct OperBoxView: View {
     @EnvironmentObject private var viewModel: MAAViewModel
 
     var body: some View {
-        List {
-            Section {
-                ForEach(ownedOpers, id: \.id) { oper in
-                    oper.label
+        VStack(spacing: 20) {
+            List {
+                Section {
+                    ForEach(ownedOpers, id: \.id) { oper in
+                        oper.label
+                    }
+                } header: {
+                    Text("已拥有干员：\(ownedOpers.count)")
                 }
-            } header: {
-                Text("已拥有干员：\(ownedOpers.count)")
-            }
 
-            Section {
-                ForEach(unownedOpers, id: \.id) { oper in
-                    Text(oper.name)
+                Section {
+                    ForEach(unownedOpers, id: \.id) { oper in
+                        Text(oper.name)
+                    }
+                } header: {
+                    Text("未拥有干员：\(unownedOpers.count)")
                 }
-            } header: {
-                Text("未拥有干员：\(unownedOpers.count)")
             }
+            .animation(.default, value: viewModel.operBox)
+
+            HStack(spacing: 20) {
+                Spacer()
+                Button {
+                    copyJSONToPasteboard()
+                } label: {
+                    Label("复制 JSON", systemImage: "doc.on.doc")
+                }
+                .help("将干员列表 JSON 复制到剪贴板")
+
+                Button {
+                    exportJSONToFile()
+                } label: {
+                    Label("导出 JSON", systemImage: "square.and.arrow.up")
+                }
+                .help("将干员列表 JSON 导出为文件")
+            }
+            .disabled(viewModel.operBox?.done != true)
         }
         .padding()
-        .animation(.default, value: viewModel.operBox)
     }
 
     var ownedOpers: [MAAOperBox.OwnedOper] {
@@ -59,10 +81,54 @@ struct OperBoxView: View {
         "Sharp",
         "阿米娅-WARRIOR",
     ]
+
+    // MARK: - Export
+
+    private func copyJSONToPasteboard() {
+        guard let box = viewModel.operBox,
+              let jsonData = box.exportJSONData,
+              let jsonText = String(data: jsonData, encoding: .utf8)
+        else {
+            viewModel.logError("导出 JSON 失败")
+            return
+        }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(jsonText, forType: .string)
+        viewModel.logInfo("已复制到剪贴板")
+    }
+
+    private func exportJSONToFile() {
+        guard let box = viewModel.operBox,
+              let jsonData = box.exportJSONData
+        else {
+            viewModel.logError("导出 JSON 失败")
+            return
+        }
+
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.nameFieldStringValue = "Arknights_OperBox_Export.json"
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else {
+            return
+        }
+
+        var data = Data([0xEF, 0xBB, 0xBF])
+        data.append(jsonData)
+        do {
+            try data.write(to: url, options: .atomic)
+            viewModel.logInfo("已导出到文件")
+        }
+        catch {
+            viewModel.logError("导出 JSON 失败")
+        }
+    }
 }
 
 struct OperBoxView_Previews: PreviewProvider {
     static var previews: some View {
         OperBoxView()
+            .environmentObject(MAAViewModel())
     }
 }

--- a/MeoAsstMac/Views/OperBoxView.swift
+++ b/MeoAsstMac/Views/OperBoxView.swift
@@ -94,7 +94,10 @@ struct OperBoxView: View {
         }
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        pasteboard.setString(jsonText, forType: .string)
+        guard pasteboard.setString(jsonText, forType: .string) else {
+            viewModel.logError("导出 JSON 失败")
+            return
+        }
         viewModel.logInfo("已复制到剪贴板")
     }
 

--- a/MeoAsstMac/Views/OperBoxView.swift
+++ b/MeoAsstMac/Views/OperBoxView.swift
@@ -49,7 +49,7 @@ struct OperBoxView: View {
                 }
                 .help("将干员列表 JSON 导出为文件")
             }
-            .disabled(viewModel.operBox?.done != true)
+            .disabled(viewModel.operBox?.done != true || viewModel.status != .idle)
         }
         .padding()
     }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4946,6 +4946,76 @@
           }
         }
       }
+    },
+    "复制 JSON" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON 복사"
+          }
+        }
+      }
+    },
+    "导出 JSON" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON 내보내기"
+          }
+        }
+      }
+    },
+    "已复制到剪贴板" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클립보드에 복사됨"
+          }
+        }
+      }
+    },
+    "已导出到文件" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "파일로 내보냄"
+          }
+        }
+      }
+    },
+    "导出 JSON 失败" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON 내보내기 실패"
+          }
+        }
+      }
+    },
+    "将干员列表 JSON 复制到剪贴板" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오퍼레이터 목록 JSON을 클립보드에 복사"
+          }
+        }
+      }
+    },
+    "将干员列表 JSON 导出为文件" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오퍼레이터 목록 JSON을 파일로 내보내기"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"


### PR DESCRIPTION
close #120

### 背景

Windows「实用工具 → 干员列表」早已支持 BOX 导出，macOS 缺位。本 PR 补上「复制 JSON / 导出 JSON」两个操作，输出格式与 Windows 完全一致。

### 改动内容

1. **数据转换与序列化**（`MeoAsstMac/Model/MAAOperBox.swift`）
   - 新增 `ExportItem`，字段声明顺序即 Windows 序列化顺序；
   - 以 `all_opers` 为全量、按 `id` 合并 `own_opers` 的 `elite/level/potential`；未匹配到的一律按未拥有导出；
   - 剔除未实装/试用干员：31 个 charId 与 Windows `DataHelper._virtualOperators` 逐条对齐；
   - 手写 JSON 输出：该工具链下 `JSONEncoder` 不保证键序，故逐字段生成以保证与 Json.NET（`Formatting.Indented`，2 空格缩进）一致。

2. **视图操作**（`MeoAsstMac/Views/OperBoxView.swift`）
   - 「复制 JSON」→ 写入 `NSPasteboard`；
   - 「导出 JSON…」→ `NSSavePanel`，默认名 `Arknights_OperBox_Export.json`，写 UTF-8 BOM（`EF BB BF`）+ 正文；
   - 识别未完成（`done != true`）或无数据时按钮禁用；
   - 成功/失败通过日志提示，不做任何持久化或状态改动。

3. **本地化**：新增按钮、tooltip、结果提示均已补 ko 翻译（其余语言回退 catalog 源语言 zh-Hans）。

### 与 Windows 的契约对照

| 点 | Windows | 本 PR |
|---|---|---|
| 范围 | 全量干员（含未拥有） | `all_opers`（全量，含未拥有） |
| 未拥有 | `elite/level/potential=0, own=false` | 同左 |
| 未实装/试用干员 | `_virtualOperators` 名单剔除 | 同名 31 个 charId 剔除 |
| 键序 | Json.NET 声明序 | 手写固定 `id,name,elite,level,own,potential,rarity` |
| 文件 | UTF-8 BOM，默认名 `Arknights_OperBox_Export.json` | 同左 |
| 剪贴板 | 同一 JSON（无 BOM） | 同左 |

### 验证

- Release (arm64) `xcodebuild` 编译通过；
- 导出文件 `xxd` 首三字节为 `EF BB BF`；去掉 BOM 后 `jq` 可解析为顶层数组；
- 抽查未拥有项三项为 0、`own=false`；键序与 Windows 输出逐项一致。

## Sourcery 摘要

为 macOS 操作员列表添加兼容 Windows 的 JSON 导出支持。

新功能：
- 为 macOS 操作员列表添加 JSON 复制到剪贴板和文件导出操作，使用兼容 Windows 的格式。

改进：
- 从完整的操作员名单生成导出内容，同时合并所有权数据，并排除虚拟或未实现的操作员，以匹配 Windows 的行为。
- 提供导出可用性检查、保存面板处理、状态日志记录，以及本地化标签和工具提示。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为 macOS 运算符列表添加兼容 Windows 的 JSON 导出选项。

新功能：
- 为 macOS 运算符列表添加兼容 Windows 的 JSON 复制和文件导出功能。

增强功能：
- 从完整的运算符列表生成导出内容，同时合并所有权数据，并排除虚拟或未实现的运算符，以匹配 Windows 的行为。
- 在运算符数据完整之前禁用导出操作，并通过日志提供成功或失败反馈。

维护工作：
- 添加本地化标签、工具提示和导出状态消息。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为 macOS 操作员列表添加兼容 Windows 的 JSON 导出支持。

新功能：
- 为 macOS 操作员列表操作添加将 JSON 复制到剪贴板或将其导出为与 Windows 格式兼容的文件的功能。

增强功能：
- 从完整的操作员列表生成导出内容，同时合并所有权数据，并排除虚拟或尚未实现的操作员，以匹配 Windows 的行为。
- 在操作员数据完整之前禁用导出操作，并通过应用程序日志报告导出结果。

杂项：
- 添加本地化标签、工具提示和导出状态消息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为 macOS 干员列表添加兼容 Windows 格式的 JSON 复制与文件导出功能。

新功能：
- 为 macOS 干员列表增加将 JSON 复制到剪贴板和导出为文件的操作。

增强功能：
- 生成与 Windows 一致的干员列表 JSON，涵盖全部干员、合并所有权数据，并排除虚拟干员。
- 在干员数据未完成加载或应用处于非空闲状态时禁用导出操作，并提供导出结果反馈。

维护工作：
- 补充导出功能的本地化文本。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为 macOS 操作员列表添加兼容 Windows 的 JSON 导出支持。

新功能：
- 为 macOS 操作员列表添加操作，可将 JSON 复制到剪贴板或以兼容 Windows 的格式导出到文件。

增强功能：
- 从完整的操作员名单生成导出内容，同时合并所有权数据，并排除虚拟或尚未实现的操作员，以匹配 Windows 的行为。
- 在操作员数据加载完成前禁用导出操作，并提供成功或失败反馈。

杂项：
- 添加本地化标签、工具提示和导出状态消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Windows-compatible JSON export support to the macOS operator list.

New Features:
- Add macOS operator-list actions to copy JSON to the clipboard or export it to a file in a Windows-compatible format.

Enhancements:
- Generate exports from the complete operator roster while merging ownership data and excluding virtual or unimplemented operators to match Windows behavior.
- Disable export actions until operator data is complete and provide success or failure feedback.

Chores:
- Add localized labels, tooltips, and export status messages.

</details>

</details>

</details>

</details>

</details>