### PR TITLE
feat: 自定义基建支持按时间轮换班次

### DIFF
--- a/MeoAsstMac.xcodeproj/project.pbxproj
+++ b/MeoAsstMac.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		92F78D4F2A0B361C00999BD0 /* TaskTimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F78D4E2A0B361C00999BD0 /* TaskTimerManager.swift */; };
 		9BC2EEB32E3F188D0039C4DB /* MiniGameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC2EEB22E3F188D0039C4DB /* MiniGameView.swift */; };
 		AEA8E3A02E77003F00355D84 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = AEA8E39F2E77003F00355D84 /* AppIcon.icon */; };
+		A10700000000000000000001 /* InfrastTimeRotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10700000000000000000002 /* InfrastTimeRotationTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -238,6 +239,8 @@
 		92F78D4E2A0B361C00999BD0 /* TaskTimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTimerManager.swift; sourceTree = "<group>"; };
 		9BC2EEB22E3F188D0039C4DB /* MiniGameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniGameView.swift; sourceTree = "<group>"; };
 		AEA8E39F2E77003F00355D84 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
+		A10700000000000000000002 /* InfrastTimeRotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfrastTimeRotationTests.swift; sourceTree = "<group>"; };
+		A10700000000000000000003 /* MeoAsstMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MeoAsstMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -257,7 +260,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A10700000000000000000007 = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
 /* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXContainerItemProxy section */
+		A1070000000000000000000C = {isa = PBXContainerItemProxy; containerPortal = 833786C328F188D800D39D6F /* Project object */; proxyType = 1; remoteGlobalIDString = 833786CA28F188D800D39D6F; remoteInfo = MAA; };
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXTargetDependency section */
+		A1070000000000000000000D /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = 833786CA28F188D800D39D6F /* MAA */; targetProxy = A1070000000000000000000C; };
+/* End PBXTargetDependency section */
 
 /* Begin PBXGroup section */
 		83245A0128F467C300ED6D4C /* Frameworks */ = {
@@ -371,6 +383,7 @@
 			children = (
 				8337871028F1DF4A00D39D6F /* ExternalTools */,
 				833786CD28F188D800D39D6F /* MeoAsstMac */,
+				A10700000000000000000004 /* MeoAsstMacTests */,
 				83661E2529F628DA007793CA /* Resources */,
 				8368855029BD851F00C5B999 /* Version.xcconfig */,
 				83885C112C4D5D1500B02663 /* README.md */,
@@ -384,6 +397,7 @@
 			isa = PBXGroup;
 			children = (
 				833786CB28F188D800D39D6F /* MAA.app */,
+				A10700000000000000000003 /* MeoAsstMacTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -503,6 +517,12 @@
 			path = Utils;
 			sourceTree = "<group>";
 		};
+		A10700000000000000000004 /* MeoAsstMacTests */ = {
+			isa = PBXGroup;
+			children = (A10700000000000000000002 /* InfrastTimeRotationTests.swift */, );
+			path = MeoAsstMacTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -531,6 +551,21 @@
 			productReference = 833786CB28F188D800D39D6F /* MAA.app */;
 			productType = "com.apple.product-type.application";
 		};
+		A10700000000000000000005 /* MeoAsstMacTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10700000000000000000009 /* Build configuration list for PBXNativeTarget "MeoAsstMacTests" */;
+			buildPhases = (
+				A10700000000000000000006 /* Sources */,
+				A10700000000000000000007 /* Frameworks */,
+				A10700000000000000000008 /* Resources */,
+			);
+			buildRules = ();
+			dependencies = (A1070000000000000000000D /* PBXTargetDependency */, );
+			name = MeoAsstMacTests;
+			productName = MeoAsstMacTests;
+			productReference = A10700000000000000000003 /* MeoAsstMacTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -541,6 +576,10 @@
 				LastSwiftUpdateCheck = 1430;
 				LastUpgradeCheck = 2660;
 				TargetAttributes = {
+					A10700000000000000000005 = {
+						CreatedOnToolsVersion = 26.0;
+						TestTargetID = 833786CA28F188D800D39D6F;
+					};
 					833786CA28F188D800D39D6F = {
 						CreatedOnToolsVersion = 14.0.1;
 					};
@@ -566,6 +605,7 @@
 			projectRoot = "";
 			targets = (
 				833786CA28F188D800D39D6F /* MAA */,
+				A10700000000000000000005 /* MeoAsstMacTests */,
 			);
 		};
 /* End PBXProject section */
@@ -583,6 +623,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A10700000000000000000008 = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -673,6 +714,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A10700000000000000000006 = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (A10700000000000000000001 /* InfrastTimeRotationTests.swift in Sources */, ); runOnlyForDeploymentPostprocessing = 0; };
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
@@ -865,6 +907,36 @@
 			};
 			name = Release;
 		};
+		A1070000000000000000000A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@loader_path/../Frameworks", );
+				PRODUCT_BUNDLE_IDENTIFIER = com.hguandl.MeoAsstMacTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MAA.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MAA";
+			};
+			name = Debug;
+		};
+		A1070000000000000000000B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/../Frameworks", "@loader_path/../Frameworks", );
+				PRODUCT_BUNDLE_IDENTIFIER = com.hguandl.MeoAsstMacTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MAA.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/MAA";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -883,6 +955,12 @@
 				833786DB28F188D900D39D6F /* Debug */,
 				83E9D13E294B8C310091D1FF /* Release */,
 			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		A10700000000000000000009 /* Build configuration list for PBXNativeTarget "MeoAsstMacTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (A1070000000000000000000A /* Debug */, A1070000000000000000000B /* Release */, );
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};

--- a/MeoAsstMac.xcodeproj/xcshareddata/xcschemes/MAA.xcscheme
+++ b/MeoAsstMac.xcodeproj/xcshareddata/xcschemes/MAA.xcscheme
@@ -28,6 +28,15 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A10700000000000000000005"
+               BuildableName = "MeoAsstMacTests.xctest"
+               BlueprintName = "MeoAsstMacTests"
+               ReferencedContainer = "container:MeoAsstMac.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/MeoAsstMac/Configuration Views/InfrastSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/InfrastSettingsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct InfrastSettingsView: View {
     @Environment(\.defaultMinListRowHeight) private var rowHeight
+    @Environment(\.isEnabled) private var isEnabled
 
     @Binding var config: InfrastConfiguration
 
@@ -53,6 +54,10 @@ struct InfrastSettingsView: View {
         }
         .animation(.default, value: config.mode)
         .padding()
+        .onAppear {
+            if isEnabled { config.refreshCustomPlanSelection() }
+        }
+        .onChange(of: config.mode) { config.reloadCustomPlan() }
     }
 
     @ViewBuilder private var facilityList: some View {
@@ -107,9 +112,26 @@ struct InfrastSettingsView: View {
                     Text("内置排班")
                 }
             }
+            .id(refreshCustomPlans)
 
-            Picker("班次", selection: $config.plan_index) {
-                try? MAAInfrast(path: config.filename).planList
+            TimelineView(.periodic(from: .now, by: 60)) { context in
+                Picker("班次", selection: $config.plan_index) {
+                    if config.customPlan.hasPeriods {
+                        let index = try? config.customPlan.select(-1, at: context.date).index
+                        Text("时间轮换（\(config.customPlan.name(at: index ?? 0))）").tag(-1)
+                    }
+                    ForEach(Array(config.customPlan.plans.enumerated()), id: \.offset) { index, plan in
+                        Text(plan.name ?? "\(index)").tag(index)
+                    }
+                }
+            }
+
+            if let error = config.customPlanError {
+                Text("自定义基建配置文件解析错误：\(error)")
+                    .foregroundStyle(.red)
+            } else if config.customPlan.hasMixedPeriods {
+                Text("自定义基建配置仅有部分计划存在时间段，请全部设置时间段或全部留空。")
+                    .foregroundStyle(.orange)
             }
 
             HStack(spacing: 20) {
@@ -117,6 +139,7 @@ struct InfrastSettingsView: View {
                     NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: customInfrastDirectory.path)
                 }
                 Button("重新加载文件") {
+                    config.reloadCustomPlan()
                     refreshCustomPlans.toggle()
                 }
             }
@@ -129,8 +152,10 @@ struct InfrastSettingsView: View {
         Binding {
             config.filename
         } set: {
-            config.plan_index = 0
-            config.filename = $0
+            var updated = config
+            updated.filename = $0
+            updated.reloadCustomPlan(resetSelection: true)
+            config = updated
         }
     }
 

--- a/MeoAsstMac/Core/MaaMessage.swift
+++ b/MeoAsstMac/Core/MaaMessage.swift
@@ -150,13 +150,10 @@ extension MAAViewModel {
             if taskChain == "Infrast" {
                 if let id = taskID(taskDetails: message.details),
                     let task = tasks[id],
-                    case .infrast(let config) = task,
-                    let plan = try? MAAInfrast(path: config.filename),
-                    plan.plans.count > 0
+                    case .infrast(var config) = task
                 {
-                    var newConfig = config
-                    newConfig.plan_index = (config.plan_index + 1) % plan.plans.count
-                    tasks[id] = .infrast(newConfig)
+                    config.advanceCustomPlan()
+                    tasks[id] = .infrast(config)
                 }
             }
 

--- a/MeoAsstMac/Model/MAAInfrast.swift
+++ b/MeoAsstMac/Model/MAAInfrast.swift
@@ -5,31 +5,119 @@
 //  Created by hguandl on 20/4/2023.
 //
 
-import SwiftUI
+import Foundation
 
-struct MAAInfrast: Codable, Hashable {
+struct MAAInfrast: Codable, Hashable, Sendable {
     let title: String?
     let description: String?
     let plans: [Plan]
 
-    struct Plan: Codable, Hashable {
+    static let empty = MAAInfrast(title: nil, description: nil, plans: [])
+
+    struct Plan: Codable, Hashable, Sendable {
         let name: String?
         let description: String?
         let description_post: String?
-        let period: [[String]]?
+        let period: [Period]?
+    }
+
+    struct Period: Codable, Hashable, Sendable {
+        let start: Double
+        let end: Double
+        private let times: [String]
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let times = try container.decode([String].self)
+            guard times.count == 2,
+                let start = Self.seconds(times[0]), let end = Self.seconds(times[1])
+            else {
+                throw DecodingError.dataCorruptedError(
+                    in: container, debugDescription: "period must contain two valid times (HH:mm)")
+            }
+            self.times = times
+            self.start = start
+            self.end = end
+        }
+
+        func encode(to encoder: any Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(times)
+        }
+
+        private static func seconds(_ time: String) -> Double? {
+            let parts = time.trimmingCharacters(in: .whitespaces).split(
+                separator: ":", omittingEmptySubsequences: false)
+            guard (2...3).contains(parts.count),
+                let hour = Int(parts[0]), (0..<24).contains(hour),
+                let minute = Int(parts[1]), (0..<60).contains(minute),
+                parts[0].allSatisfy({ $0.isASCII && $0.isNumber }),
+                parts[1].allSatisfy({ $0.isASCII && $0.isNumber })
+            else { return nil }
+            let second = parts.count == 3 ? Double(parts[2]) : 0
+            guard let second, second >= 0, second < 60 else { return nil }
+            return Double(hour * 3600 + minute * 60) + second
+        }
     }
 }
 
 extension MAAInfrast {
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        plans = container.contains(.plans) ? try container.decode([Plan].self, forKey: .plans) : []
+    }
+
     init(path: String) throws {
         let url = URL(fileURLWithPath: path)
         let data = try Data(contentsOf: url)
         self = try JSONDecoder().decode(MAAInfrast.self, from: data)
     }
 
-    var planList: some View {
-        ForEach(Array(plans.enumerated()), id: \.offset) {
-            Text($0.element.name ?? "\($0.offset)").tag($0.offset)
+    var hasPeriods: Bool { plans.contains { !($0.period ?? []).isEmpty } }
+    var hasMixedPeriods: Bool { hasPeriods && plans.contains { ($0.period ?? []).isEmpty } }
+    var defaultSelection: Int { hasPeriods ? -1 : 0 }
+
+    // Windows retains valid selections; a missing list item becomes time rotation,
+    // even when the refreshed list contains no time-rotation item.
+    func refreshedSelection(_ selection: Int) -> Int {
+        plans.indices.contains(selection) || (selection == -1 && hasPeriods) ? selection : -1
+    }
+
+    struct Selection: Equatable, Sendable {
+        let index: Int
+        let usedFallback: Bool
+    }
+
+    enum SelectionError: LocalizedError {
+        case outOfRange
+
+        var errorDescription: String? { String(localized: "自定义基建配置选择超出索引") }
+    }
+
+    func select(_ selection: Int, at date: Date = .now, calendar: Calendar = .current) throws -> Selection {
+        if selection != -1 {
+            guard plans.indices.contains(selection) else { throw SelectionError.outOfRange }
+            return Selection(index: selection, usedFallback: false)
         }
+        let time = calendar.dateComponents([.hour, .minute, .second, .nanosecond], from: date)
+        let now =
+            Double((time.hour ?? 0) * 3600 + (time.minute ?? 0) * 60 + (time.second ?? 0))
+            + Double(time.nanosecond ?? 0) / 1_000_000_000
+        let index = plans.firstIndex { plan in
+            (plan.period ?? []).contains { $0.start <= now && now <= $0.end }
+        }
+        return Selection(index: index ?? 0, usedFallback: index == nil)
+    }
+
+    func nextSelection(after selection: Int) -> Int? {
+        guard plans.indices.contains(selection) else { return nil }
+        return (selection + 1) % plans.count
+    }
+
+    func name(at index: Int) -> String {
+        guard plans.indices.contains(index) else { return "???" }
+        return plans[index].name ?? "\(index)"
     }
 }

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -427,6 +427,8 @@ extension MAAViewModel {
     func tryStartTasks() async {
         do {
             try await startTasks()
+        } catch let error as MAAInfrast.SelectionError {
+            logError("\(error.localizedDescription)")
         } catch {
             logError("ConnectFailed")
             logInfo("CheckSettings")
@@ -468,7 +470,26 @@ extension MAAViewModel {
         for task in tasks {
             guard task.enabled else { continue }
 
-            if let coreID = try await handle?.appendTask(task.task) {
+            let coreID: Int32?
+            if case .infrast(let config) = task.task, config.mode == .custom {
+                if let error = config.customPlanError {
+                    logError("自定义基建配置文件解析错误：\(error)")
+                }
+                if config.customPlan.hasMixedPeriods {
+                    logWarn("自定义基建配置仅有部分计划存在时间段，请全部设置时间段或全部留空。")
+                }
+                let execution = try config.execution()
+                if execution.selection?.usedFallback == true {
+                    logError("自定义基建配置未找到对应时间段的计划，使用第一个班次。")
+                }
+                let name = config.customPlan.name(at: execution.configuration.plan_index)
+                logInfo("自定义基建班次：\(name)")
+                coreID = try await handle?.appendTask(
+                    type: .Infrast, params: execution.configuration.jsonString())
+            } else {
+                coreID = try await handle?.appendTask(task.task)
+            }
+            if let coreID {
                 taskIDMap[coreID] = task.id
             }
         }

--- a/MeoAsstMac/Navigation/TaskDetail.swift
+++ b/MeoAsstMac/Navigation/TaskDetail.swift
@@ -23,6 +23,7 @@ struct TaskDetail: View {
                         RecruitSettingsView(config: taskConfigBinding(config, id: id))
                     case .infrast(let config):
                         InfrastSettingsView(config: taskConfigBinding(config, id: id))
+                            .disabled(viewModel.status != .idle)
                     case .fight(let config):
                         FightSettingsView(config: taskConfigBinding(config, id: id))
                     case .mall(let config):

--- a/MeoAsstMac/Task Configurations/InfrastConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/InfrastConfiguration.swift
@@ -54,6 +54,16 @@ struct InfrastConfiguration: MAATaskConfiguration {
     var filename: String
     var plan_index: Int
 
+    // GUI-only parsed state. Keep it stable while a task runs, as in Windows.
+    private(set) var customPlan = MAAInfrast.empty
+    private(set) var customPlanError: String?
+
+    enum CodingKeys: String, CodingKey {
+        case mode, facility, drones, threshold, replenish
+        case dorm_notstationed_enabled, dorm_trust_enabled, continue_training, reception_message_board
+        case filename, plan_index
+    }
+
     var title: String {
         type.description
     }
@@ -63,8 +73,8 @@ struct InfrastConfiguration: MAATaskConfiguration {
             return String(localized: "默认换班")
         }
 
-        if let plan = try? MAAInfrast(path: filename) {
-            return plan.title ?? filename
+        if customPlanError == nil {
+            return customPlan.title ?? filename
         } else {
             return String(localized: "无法识别配置")
         }
@@ -75,26 +85,67 @@ struct InfrastConfiguration: MAATaskConfiguration {
             return String(localized: "单设施最优解")
         }
 
-        if let plan = try? MAAInfrast(path: filename), plan_index < plan.plans.count {
-            return plan.plans[plan_index].name ?? "\(plan_index)"
-        } else {
-            return String(localized: "未知排班")
-        }
+        if plan_index == -1 { return String(localized: "时间轮换") }
+        return customPlan.plans.indices.contains(plan_index)
+            ? customPlan.name(at: plan_index) : String(localized: "未知排班")
     }
 
     var projectedTask: MAATask {
         .infrast(self)
     }
 
-    typealias Params = Self
+    struct Params: Encodable {
+        let configuration: InfrastConfiguration
 
-    var params: Self {
-        self
+        func encode(to encoder: any Encoder) throws {
+            try configuration.execution().configuration.encode(to: encoder)
+        }
     }
 
-    private var customPlan: MAAInfrast? {
-        guard mode == .custom else { return nil }
-        return try? MAAInfrast(path: filename)
+    var params: Params { Params(configuration: self) }
+
+    func execution(at date: Date = .now, calendar: Calendar = .current) throws
+        -> (configuration: Self, selection: MAAInfrast.Selection?)
+    {
+        guard mode == .custom else { return (self, nil) }
+        let selection = try customPlan.select(plan_index, at: date, calendar: calendar)
+        var resolved = self
+        resolved.plan_index = selection.index
+        return (resolved, selection)
+    }
+
+    mutating func reloadCustomPlan(resetSelection: Bool = false) {
+        loadCustomPlan()
+        plan_index = resetSelection ? customPlan.defaultSelection : customPlan.refreshedSelection(plan_index)
+    }
+
+    mutating func refreshCustomPlanSelection() {
+        plan_index = customPlan.refreshedSelection(plan_index)
+    }
+
+    private mutating func loadCustomPlan() {
+        customPlan = .empty
+        customPlanError = nil
+        guard mode == .custom, FileManager.default.fileExists(atPath: filename) else { return }
+        do {
+            customPlan = try MAAInfrast(path: filename)
+        } catch {
+            customPlanError = error.localizedDescription
+        }
+    }
+
+    mutating func restoreCustomPlan() {
+        // Windows leaves a missing file's saved selection alone. An existing
+        // file that cannot be parsed resets the selection to zero instead.
+        guard mode == .custom, !filename.isEmpty, FileManager.default.fileExists(atPath: filename) else { return }
+        loadCustomPlan()
+        if customPlanError != nil { plan_index = 0 }
+        if plan_index < -1 { plan_index = -1 } else if plan_index >= customPlan.plans.count { plan_index = 0 }
+    }
+
+    mutating func advanceCustomPlan() {
+        guard mode == .custom, let next = customPlan.nextSelection(after: plan_index) else { return }
+        plan_index = next
     }
 }
 
@@ -165,5 +216,6 @@ extension InfrastConfiguration {
         self.continue_training = try container.decodeIfPresent(Bool.self, forKey: .continue_training) ?? true
         self.reception_message_board =
             try container.decodeIfPresent(Bool.self, forKey: .reception_message_board) ?? true
+        restoreCustomPlan()
     }
 }

--- a/MeoAsstMac/Task Configurations/LegacyConfigurations.swift
+++ b/MeoAsstMac/Task Configurations/LegacyConfigurations.swift
@@ -83,6 +83,7 @@ extension InfrastConfiguration {
         self.plan_index = config.plan_index
         self.continue_training = true
         self.reception_message_board = true
+        restoreCustomPlan()
     }
 }
 

--- a/MeoAsstMacTests/InfrastTimeRotationTests.swift
+++ b/MeoAsstMacTests/InfrastTimeRotationTests.swift
@@ -1,0 +1,284 @@
+import XCTest
+
+@testable import MAA
+
+final class InfrastTimeRotationTests: XCTestCase {
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private func time(_ hour: Int, _ minute: Int = 0, _ second: Int = 0) -> Date {
+        calendar.date(
+            from: DateComponents(
+                year: 2026, month: 9, day: 7,
+                hour: hour, minute: minute, second: second))!
+    }
+
+    private func configuration(_ plans: String) throws -> MAAInfrast {
+        try JSONDecoder().decode(MAAInfrast.self, from: Data("{\"plans\":\(plans)}".utf8))
+    }
+
+    func testMatchesFirstOverlappingPlanAndAnyPeriodWithinAPlan() throws {
+        let config = try configuration(
+            #"[{"period":[["6:00","13:59"],["18:00","20:00"]]},{"period":[["12:00","22:00"]]}]"#)
+        XCTAssertEqual(try config.select(-1, at: time(13), calendar: calendar).index, 0)
+        XCTAssertEqual(try config.select(-1, at: time(15), calendar: calendar).index, 1)
+        let evening = try config.select(-1, at: time(19), calendar: calendar)
+        XCTAssertEqual(evening.index, 0)
+        XCTAssertFalse(evening.usedFallback)
+    }
+
+    func testEndpointsAreInclusiveButEndMinuteDoesNotIncludeLaterSeconds() throws {
+        let config = try configuration(#"[{"period":[["6:00","13:59"]]},{"period":[["14:00","21:59"]]}]"#)
+        for date in [time(6), time(13, 59), time(14), time(21, 59)] {
+            XCTAssertFalse(try config.select(-1, at: date, calendar: calendar).usedFallback)
+        }
+        for date in [time(5, 59, 59), time(13, 59, 1), time(13, 59, 30), time(21, 59, 1)] {
+            let selection = try config.select(-1, at: date, calendar: calendar)
+            XCTAssertEqual(selection.index, 0)
+            XCTAssertTrue(selection.usedFallback)
+        }
+    }
+
+    func testCrossMidnightRequiresSeparatePeriods() throws {
+        let unsplit = try configuration(#"[{"period":[["22:00","06:00"]]}]"#)
+        let split = try configuration(#"[{"period":[["22:00","23:59"],["00:00","06:00"]]}]"#)
+        for date in [time(23), time(0), time(5)] {
+            XCTAssertTrue(try unsplit.select(-1, at: date, calendar: calendar).usedFallback)
+            XCTAssertFalse(try split.select(-1, at: date, calendar: calendar).usedFallback)
+        }
+    }
+
+    func testMissingNullAndEmptyPeriodsAllowManualSelection() throws {
+        let config = try configuration(#"[{},{"period":null},{"period":[]}]"#)
+        XCTAssertFalse(config.hasPeriods)
+        XCTAssertFalse(config.hasMixedPeriods)
+        XCTAssertEqual(config.defaultSelection, 0)
+        let manual = try config.select(2, at: time(12), calendar: calendar)
+        XCTAssertEqual(manual.index, 2)
+        XCTAssertFalse(manual.usedFallback)
+        XCTAssertTrue(try config.select(-1, at: time(12), calendar: calendar).usedFallback)
+        XCTAssertThrowsError(try config.select(3, at: time(12), calendar: calendar))
+        XCTAssertThrowsError(try config.select(-2, at: time(12), calendar: calendar))
+    }
+
+    func testMixedPeriodsDefaultToRotationAndSkipUnscheduledPlans() throws {
+        let config = try configuration(#"[{},{"period":[["00:00","23:59"]]}]"#)
+        XCTAssertTrue(config.hasPeriods)
+        XCTAssertTrue(config.hasMixedPeriods)
+        XCTAssertEqual(config.defaultSelection, -1)
+        XCTAssertEqual(try config.select(-1, at: time(12), calendar: calendar).index, 1)
+    }
+
+    func testEmptyPlansUseWindowsRotationFallback() throws {
+        let config = try configuration("[]")
+        XCTAssertFalse(config.hasPeriods)
+        XCTAssertFalse(config.hasMixedPeriods)
+        let selection = try config.select(-1, at: time(12), calendar: calendar)
+        XCTAssertEqual(selection.index, 0)
+        XCTAssertTrue(selection.usedFallback)
+        XCTAssertThrowsError(try config.select(0, at: time(12), calendar: calendar))
+        XCTAssertEqual(config.refreshedSelection(0), -1)
+        XCTAssertNil(config.nextSelection(after: 0))
+    }
+
+    func testInvalidPeriodsFailDecoding() {
+        for period in [
+            #"[["06:00"]]"#, #"[["06:00","12:00","18:00"]]"#,
+            #"[["24:00","06:00"]]"#, #"[["06:60","12:00"]]"#,
+            #"[["invalid","12:00"]]"#, #"[[null,"12:00"]]"#,
+        ] {
+            XCTAssertThrowsError(try configuration("[{\"period\":\(period)}]"), period)
+        }
+    }
+
+    func testMissingPlansAreEmptyButExplicitNullIsAnError() throws {
+        let missing = try JSONDecoder().decode(MAAInfrast.self, from: Data("{}".utf8))
+        XCTAssertTrue(missing.plans.isEmpty)
+        XCTAssertThrowsError(try configuration("null"))
+    }
+
+    func testRefreshPreservesAvailableChoicesAndUsesWindowsInvalidSelection() throws {
+        let scheduled = try configuration(#"[{"period":[["06:00","18:00"]]},{}]"#)
+        XCTAssertEqual(scheduled.refreshedSelection(-1), -1)
+        XCTAssertEqual(scheduled.refreshedSelection(1), 1)
+        XCTAssertEqual(scheduled.refreshedSelection(2), -1)
+        let manual = try configuration("[{}]")
+        XCTAssertEqual(manual.refreshedSelection(0), 0)
+        XCTAssertEqual(manual.refreshedSelection(1), -1)
+        XCTAssertEqual(manual.refreshedSelection(-1), -1)
+    }
+
+    func testOnlyValidManualChoicesAdvanceAndWrap() throws {
+        let config = try configuration(#"[{"period":[["06:00","18:00"]]},{}]"#)
+        XCTAssertEqual(config.nextSelection(after: 0), 1)
+        XCTAssertEqual(config.nextSelection(after: 1), 0)
+        XCTAssertNil(config.nextSelection(after: -1))
+        XCTAssertNil(config.nextSelection(after: 2))
+        XCTAssertEqual(try configuration("[{}]").nextSelection(after: 0), 0)
+    }
+
+    func testMatchingUsesSuppliedLocalCalendar() throws {
+        let config = try configuration(#"[{"period":[["06:00","07:00"]]}]"#)
+        var local = calendar
+        local.timeZone = TimeZone(secondsFromGMT: 8 * 3600)!
+        let date = time(22, 30)
+        XCTAssertTrue(try config.select(-1, at: date, calendar: calendar).usedFallback)
+        XCTAssertFalse(try config.select(-1, at: date, calendar: local).usedFallback)
+    }
+}
+
+extension InfrastTimeRotationTests {
+    private func withPlanFile(_ plans: String, body: (URL) throws -> Void) throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try writePlans(plans, to: url)
+        try body(url)
+    }
+
+    private func writePlans(_ plans: String, to url: URL) throws {
+        try Data("{\"plans\":\(plans)}".utf8).write(to: url)
+    }
+
+    private func taskConfiguration(file: URL, selection: Int = -1) throws -> InfrastConfiguration {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "mode": 10000, "filename": file.path, "plan_index": selection,
+        ])
+        return try JSONDecoder().decode(InfrastConfiguration.self, from: data)
+    }
+
+    private func encodedObject<T: Encodable>(_ value: T) throws -> [String: Any] {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: JSONEncoder().encode(value)) as? [String: Any])
+    }
+
+    func testExecutionResolvesIndexWithoutChangingPersistedRotation() throws {
+        try withPlanFile(#"[{"period":[["06:00","13:59"]]},{"period":[["14:00","21:59"]]}]"#) { url in
+            let config = try taskConfiguration(file: url)
+            let execution = try config.execution(at: time(15), calendar: calendar)
+            XCTAssertEqual(execution.configuration.plan_index, 1)
+            XCTAssertEqual(execution.selection?.index, 1)
+            XCTAssertEqual(execution.selection?.usedFallback, false)
+            XCTAssertEqual(config.plan_index, -1)
+            let persisted = try encodedObject(config)
+            XCTAssertEqual(persisted["plan_index"] as? Int, -1)
+            XCTAssertNil(persisted["customPlan"])
+            XCTAssertNil(persisted["customPlanError"])
+        }
+    }
+
+    func testCoreParamsResolveRotationIncludingEmptyPlans() throws {
+        try withPlanFile(#"[{"period":[["00:00","23:59"]]}]"#) { url in
+            let config = try taskConfiguration(file: url)
+            XCTAssertEqual(try encodedObject(config.params)["plan_index"] as? Int, 0)
+            XCTAssertEqual(config.plan_index, -1)
+        }
+        try withPlanFile("[]") { url in
+            let config = try taskConfiguration(file: url)
+            XCTAssertEqual(try encodedObject(config.params)["plan_index"] as? Int, 0)
+            XCTAssertEqual(config.plan_index, -1)
+        }
+    }
+
+    func testPlistReopenPreservesManualAndRotationSelections() throws {
+        try withPlanFile(#"[{"period":[["06:00","13:59"]]},{"period":[["14:00","21:59"]]}]"#) { url in
+            for selection in [-1, 0, 1] {
+                let original = try taskConfiguration(file: url, selection: selection)
+                let data = try PropertyListEncoder().encode(original)
+                let reopened = try PropertyListDecoder().decode(InfrastConfiguration.self, from: data)
+                XCTAssertEqual(reopened.plan_index, selection)
+                XCTAssertEqual(reopened.filename, url.path)
+                XCTAssertTrue(reopened.customPlan.hasPeriods)
+                XCTAssertNil(reopened.customPlanError)
+            }
+        }
+    }
+
+    func testFileSwitchDefaultsAndReloadRetainsOnlyAvailableChoices() throws {
+        try withPlanFile(#"[{"period":[["06:00","18:00"]]},{}]"#) { scheduledURL in
+            try withPlanFile("[{}]") { manualURL in
+                var config = try taskConfiguration(file: manualURL, selection: 0)
+                config.filename = scheduledURL.path
+                config.reloadCustomPlan(resetSelection: true)
+                XCTAssertEqual(config.plan_index, -1)
+                config.plan_index = 1
+                config.reloadCustomPlan()
+                XCTAssertEqual(config.plan_index, 1)
+                config.filename = manualURL.path
+                config.reloadCustomPlan(resetSelection: true)
+                XCTAssertEqual(config.plan_index, 0)
+                config.plan_index = 1
+                config.reloadCustomPlan()
+                XCTAssertEqual(config.plan_index, -1)
+                config.refreshCustomPlanSelection()
+                XCTAssertEqual(config.plan_index, -1)
+            }
+        }
+    }
+
+    func testExecutionUsesCachedPlansUntilExplicitReload() throws {
+        try withPlanFile(#"[{"period":[["06:00","13:59"]]},{"period":[["14:00","21:59"]]}]"#) { url in
+            var config = try taskConfiguration(file: url)
+            XCTAssertEqual(try config.execution(at: time(15), calendar: calendar).configuration.plan_index, 1)
+            try writePlans(#"[{"period":[["14:00","21:59"]]},{"period":[["06:00","13:59"]]}]"#, to: url)
+            config.refreshCustomPlanSelection()
+            XCTAssertEqual(try config.execution(at: time(15), calendar: calendar).configuration.plan_index, 1)
+            config.reloadCustomPlan()
+            XCTAssertEqual(try config.execution(at: time(15), calendar: calendar).configuration.plan_index, 0)
+            XCTAssertEqual(config.plan_index, -1)
+        }
+    }
+
+    func testReopenDistinguishesMissingAndMalformedFilesLikeWindows() throws {
+        try withPlanFile("[]") { url in
+            try Data("broken JSON".utf8).write(to: url)
+            var malformed = try taskConfiguration(file: url)
+            XCTAssertEqual(malformed.plan_index, 0)
+            XCTAssertNotNil(malformed.customPlanError)
+            XCTAssertThrowsError(try JSONEncoder().encode(malformed.params))
+            // Opening the settings refreshes the absent item to -1, as Windows does.
+            malformed.refreshCustomPlanSelection()
+            XCTAssertEqual(malformed.plan_index, -1)
+            XCTAssertEqual(try encodedObject(malformed.params)["plan_index"] as? Int, 0)
+
+            try FileManager.default.removeItem(at: url)
+            let missing = try taskConfiguration(file: url)
+            XCTAssertEqual(missing.plan_index, -1)
+            XCTAssertNil(missing.customPlanError)
+            XCTAssertEqual(try encodedObject(missing.params)["plan_index"] as? Int, 0)
+        }
+    }
+
+    func testRestoringDirectlyConstructedConfigurationLoadsCachedPlan() throws {
+        try withPlanFile("[{},{}]") { url in
+            var config = InfrastConfiguration()
+            config.mode = .custom
+            config.filename = url.path
+            config.plan_index = 1
+            config.restoreCustomPlan()
+            XCTAssertEqual(config.customPlan.plans.count, 2)
+            XCTAssertEqual(config.plan_index, 1)
+            XCTAssertEqual(try encodedObject(config.params)["plan_index"] as? Int, 1)
+        }
+    }
+
+    func testCompletionOnlyAdvancesManualCustomMode() throws {
+        try withPlanFile(#"[{"period":[["06:00","18:00"]]},{}]"#) { url in
+            var config = try taskConfiguration(file: url)
+            config.advanceCustomPlan()
+            XCTAssertEqual(config.plan_index, -1)
+            config.plan_index = 0
+            config.advanceCustomPlan()
+            XCTAssertEqual(config.plan_index, 1)
+            config.advanceCustomPlan()
+            XCTAssertEqual(config.plan_index, 0)
+            for mode in [InfrastConfiguration.Mode.default, .rotation] {
+                config.mode = mode
+                config.advanceCustomPlan()
+                XCTAssertEqual(config.plan_index, 0)
+                XCTAssertNil(try config.execution(at: time(15), calendar: calendar).selection)
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ MAA 的意思是 MAA Assistant Arknights
 
 本 Repo 为 MAA 的 Mac GUI 仓库，是 MAA 主仓库的 submodule。 更多关于 MAA 的信息请参考 [MAA Assistant Arknights 主仓库](https://github.com/MaaAssistantArknights/MaaAssistantArknights)。
 
+## 自定义基建时间轮换
+
+在基建设置中选择“自定义基建配置”和排班文件。文件中任一班次包含非空 `period` 时，班次列表提供“时间轮换（当前班次）”；选择文件时默认启用时间轮换，没有时段则默认第一班。已有配置中保存的具体班次不会自动改成时间轮换。
+
+时间轮换与 Windows 一致：手动启动和定时启动均在提交任务时按电脑本地时间选班，同一班次任一时段匹配即可，多个班次重叠时选文件中靠前的一班。提交后，界面的时间预览更新不改变本次执行班次。时间轮换完成后不递增班次；手动选择具体班次则在基建完成后顺序推进，末班回到第一班。
+
+`period` 的起止点都包含在区间内，但结束分钟不会扩展为整分钟，例如 `13:59:00` 匹配结束时间 `13:59`，`13:59:30` 已不匹配。跨午夜需要拆成两段，例如 `[["22:00", "23:59"], ["00:00", "06:00"]]`。详见[基建排班协议](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master-v2/docs/zh-cn/protocol/base-scheduling-schema.md)。
+
+修改文件后点击“重新加载文件”。重载保留仍有效的选择；与 Windows 一样，失效选择会设为时间轮换状态，即使新文件已没有时段，此时下拉框可能没有对应选项。时间轮换没有匹配时段或班次列表为空时，仍向 Core 提交索引 `0` 并记录错误。解析错误会清空已加载班次；手动索引越界则报错。可重新选择文件或有效班次。任务运行期间禁止修改基建设置。
+
 ## 开发
 
 ### clone 代码

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,6 +1,76 @@
 {
   "sourceLanguage" : "zh-Hans",
   "strings" : {
+    "时间轮换" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Time rotation"
+          }
+        }
+      }
+    },
+    "时间轮换（%@）" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Time rotation (%@)"
+          }
+        }
+      }
+    },
+    "自定义基建配置选择超出索引" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom base plan selection is out of range"
+          }
+        }
+      }
+    },
+    "自定义基建配置文件解析错误：%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to parse custom base configuration: %@"
+          }
+        }
+      }
+    },
+    "自定义基建配置仅有部分计划存在时间段，请全部设置时间段或全部留空。" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only some custom base plans have time periods. Set periods for all plans or leave all empty."
+          }
+        }
+      }
+    },
+    "自定义基建配置未找到对应时间段的计划，使用第一个班次。" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No custom base plan matches the current time. Using the first plan."
+          }
+        }
+      }
+    },
+    "自定义基建班次：%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom base plan: %@"
+          }
+        }
+      }
+    },
     "" : {
       "shouldTranslate" : false
     },


### PR DESCRIPTION
## 改动内容

为自定义基建增加“时间轮换”选项，根据排班文件的 period，
在手动或定时启动提交任务时按本地时间选择班次，对齐 Windows 行为。

- 自动模式保存选择状态，提交时转换为实际班次索引。
- 自动模式完成后保持时间轮换，手动模式继续顺序推进。
- 支持排班文件重新加载和当前班次预览。
- 任务运行期间禁用基建设置。

关联 MaaAssistantArknights/MaaAssistantArknights#5640。

## 验证

- macOS Debug 构建及签名检查通过。
- 19 项 XCTest 全部通过。
- 两份真实排班配置的 54 项时间选择断言通过。
- 界面验证文件切换、手动班次选择、自动预览、
  文件重新加载及手动选择的重开恢复。

## Sourcery 摘要

为 macOS 自定义基建任务加入与 Windows 对齐的本地时间轮换班次支持。

新功能：
- 为自定义基建排班支持按本地时间自动选择对应班次，并提供当前班次预览。

Bug 修复：
- 修正自定义排班文件重新加载、配置恢复及任务提交时的班次选择行为，使其保留有效选择并处理失效或无匹配情况。

改进：
- 区分自动时间轮换与手动班次选择，分别实现提交后的保持和顺序推进行为。
- 在基建任务运行期间禁用相关设置，并增加排班文件解析错误、混合时段配置和无匹配班次提示。

构建：
- 更新 Xcode 工程文件及共享构建方案。

文档：
- 补充自定义基建时间轮换的配置规则、时间匹配行为和文件重载说明。

测试：
- 新增自定义基建时间轮换、时段解析、配置恢复、文件重载及任务推进逻辑的 XCTest 覆盖。

维护：
- 增加本地化字符串支持。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为 macOS 自定义基建加入与 Windows 对齐的本地时间轮换班次支持。

新功能：
- 为 macOS 自定义基建排班增加按本地时间自动选择班次及当前班次预览。

错误修复：
- 修正自定义排班文件重载、配置恢复和任务提交时的班次选择，处理无效选择、解析错误及无匹配时段。

增强功能：
- 区分时间轮换与手动班次模式，使时间轮换模式保持当前选择，而手动模式在任务完成后按顺序推进。
- 任务运行期间禁用基建设置，并增加排班时段校验、混合配置和无匹配班次提示。

构建：
- 更新 Xcode 工程文件及共享构建方案。

文档：
- 补充自定义基建时间轮换的配置规则、时间匹配行为和文件重载说明。

测试：
- 新增时间轮换、时段解析、配置恢复、文件重载及任务推进逻辑的测试覆盖。

日常维护：
- 增加相关本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 macOS 自定义基建加入与 Windows 对齐的本地时间轮换班次支持。

New Features:
- 为 macOS 自定义基建排班增加按本地时间自动选择班次及当前班次预览。

Bug Fixes:
- 修正自定义排班文件重载、配置恢复和任务提交时的班次选择，处理失效选择、解析错误及无匹配时段。

Enhancements:
- 区分时间轮换与手动班次模式，使时间轮换保持选择而手动模式在任务完成后顺序推进。
- 任务运行期间禁用基建设置，并增加排班时段校验、混合配置和无匹配班次提示。

Build:
- 更新 Xcode 工程文件及共享构建方案。

Documentation:
- 补充自定义基建时间轮换的配置规则、时间匹配行为和文件重载说明。

Tests:
- 新增时间轮换、时段解析、配置恢复、文件重载及任务推进逻辑的测试覆盖。

Chores:
- 增加相关本地化字符串。

</details>

</details>