### PR TITLE
fix: 统一侧栏底部按钮的图标对齐

### DIFF
--- a/MeoAsstMac/Navigation/Sidebar.swift
+++ b/MeoAsstMac/Navigation/Sidebar.swift
@@ -7,13 +7,13 @@
 
 import SwiftUI
 
-struct Sidebar: View {
-    @Binding var selection: SidebarEntry?
+struct Sidebar: View {    @Binding var selection: SidebarEntry?
 
     @Binding var showUpdate: Bool
     let onUpdate: () async throws -> Void
 
     @Environment(\.defaultMinListRowHeight) var rowHeight
+    @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -38,10 +38,13 @@ struct Sidebar: View {
                     Label("查找日志…", systemImage: "doc.text.magnifyingglass")
                 }
 
-                SettingsLink {
+                Button {
+                    openSettings()
+                } label: {
                     Label("设置", systemImage: "gear")
                 }
             }
+            .labelStyle(SidebarActionLabelStyle())
             .buttonStyle(.plain)
             .padding()
         }
@@ -49,6 +52,15 @@ struct Sidebar: View {
             ResourceUpdateView(onUpdate: onUpdate)
         }
         .frame(minWidth: 150)
+    }
+}
+
+struct SidebarActionLabelStyle: LabelStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(spacing: 6) {
+            configuration.icon.frame(width: 18)
+            configuration.title
+        }
     }
 }
 


### PR DESCRIPTION
## 问题

侧栏底部四个按钮（帮助与公告 / 资源更新 / 查找日志 / 设置）中，"设置"的齿轮图标在视觉上比其他三个图标更靠左（像素测量：齿轮墨迹起始比圆形图标早约 3pt），文字则是对齐的。

## 原因

各 SF Symbol 的字形左留白不同：`gear` 的墨迹填满边界框（左留白≈0），而 `questionmark.circle` / `arrow.up.circle` 等圆形符号内部自带对称留白——布局帧对齐时视觉墨迹仍会错位。

## 修改

- 四个按钮统一应用自定义 `LabelStyle`：图标在固定宽度框内居中渲染，抹平字形留白差异（修复后四行图标起始误差 <1px）。
- "设置"从 `SettingsLink` 改为 `Button` + `@Environment(\.openSettings)`，与其他三个按钮走同一渲染路径（打开设置窗口的行为不变，`openSettings` 需 macOS 14+，与当前部署目标一致）。

单文件改动，无新增本地化词条。

## Summary by Sourcery

统一侧栏底部按钮的图标布局，确保各操作项在视觉上保持一致对齐。

Bug Fixes:
- 统一侧栏底部操作按钮的图标视觉对齐，消除不同 SF Symbol 字形留白造成的偏移。

Enhancements:
- 将设置入口纳入与其他侧栏操作一致的按钮渲染和交互路径，同时保持打开设置窗口的行为不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一侧栏底部按钮的图标布局，确保各操作项在视觉上保持一致对齐。

Bug Fixes:
- 统一侧栏底部操作按钮的图标视觉对齐，消除不同 SF Symbol 字形留白造成的偏移。

Enhancements:
- 将设置入口纳入与其他侧栏操作一致的按钮渲染和交互路径，同时保持打开设置窗口的行为不变。

</details>

## 对比

上：修复后；下：修复前（"设置"齿轮图标偏左）。

![sidebar-icon-compare](https://raw.githubusercontent.com/zhangweijian97/MaaMacGui/screenshots/sidebar-icon-compare.png)
