### PR TITLE
fix: 关于窗口版本号改取核心版本，修复自编译构建显示假 1.0

### DIFF
--- a/MeoAsstMac.xcodeproj/project.pbxproj
+++ b/MeoAsstMac.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		8307A5CF3030157700A82FF7 /* PixelPainter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8307A5CE3030157600A82FF7 /* PixelPainter.swift */; };
 		830C3D1C29BC7D8600B13A9F /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 830C3D1B29BC7D8600B13A9F /* Sparkle */; };
 		830C3D1E29BC7DE200B13A9F /* CheckForUpdatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830C3D1D29BC7DE200B13A9F /* CheckForUpdatesView.swift */; };
+		83D5A2E02E6F1A01B1C2D3E4 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D5A2DF2E6F1A01B1C2D3E4 /* AboutView.swift */; };
 		831100C43026440D00554899 /* NewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831100C33026440D00554899 /* NewViewModel.swift */; };
 		831597123028DF98008C7EDF /* CapsulePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831597113028DF98008C7EDF /* CapsulePicker.swift */; };
 		8315B0BD290E48F300AE7FDC /* StartupSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8315B0BC290E48F300AE7FDC /* StartupSettingsView.swift */; };
@@ -146,6 +147,7 @@
 /* Begin PBXFileReference section */
 		8307A5CE3030157600A82FF7 /* PixelPainter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelPainter.swift; sourceTree = "<group>"; };
 		830C3D1D29BC7DE200B13A9F /* CheckForUpdatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckForUpdatesView.swift; sourceTree = "<group>"; };
+		83D5A2DF2E6F1A01B1C2D3E4 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		830C3D1F29BC86EE00B13A9F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		831100C33026440D00554899 /* NewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewViewModel.swift; sourceTree = "<group>"; };
 		831597113028DF98008C7EDF /* CapsulePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapsulePicker.swift; sourceTree = "<group>"; };
@@ -320,6 +322,7 @@
 			isa = PBXGroup;
 			children = (
 				830C3D1D29BC7DE200B13A9F /* CheckForUpdatesView.swift */,
+				83D5A2DF2E6F1A01B1C2D3E4 /* AboutView.swift */,
 				8329858B29EDA8DB009F7ED5 /* OpenLogFileView.swift */,
 				83477CB129FEA12300A5FF99 /* TaskCommands.swift */,
 			);
@@ -623,6 +626,7 @@
 				8337870228F1D95F00D39D6F /* Maa.swift in Sources */,
 				832985B929EF9D50009F7ED5 /* MAAContent.swift in Sources */,
 				830C3D1E29BC7DE200B13A9F /* CheckForUpdatesView.swift in Sources */,
+				83D5A2E02E6F1A01B1C2D3E4 /* AboutView.swift in Sources */,
 				832985B029EEF483009F7ED5 /* ReclamationConfiguration.swift in Sources */,
 				833786CF28F188D800D39D6F /* MeoAsstMacApp.swift in Sources */,
 				83CFD47129EAACD7000428A1 /* MAATask.swift in Sources */,

--- a/MeoAsstMac/Main Menu/AboutView.swift
+++ b/MeoAsstMac/Main Menu/AboutView.swift
@@ -1,0 +1,56 @@
+//
+//  AboutView.swift
+//  MeoAsstMac
+//
+//  Created by zhangweijian on 11/9/2026.
+//
+
+import MaaCore
+import SwiftUI
+
+struct AboutView: View {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Button("关于 MAA") {
+            openWindow(id: "about")
+        }
+    }
+}
+
+struct AboutContentView: View {
+    private let coreVersion = String(cString: AsstGetVersion())
+    private let bundleVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .frame(width: 96, height: 96)
+
+            Text("MAA")
+                .font(.title2)
+                .bold()
+
+            if let bundleVersion, !bundleVersion.isEmpty {
+                Text(verbatim: "版本 \(coreVersion) (\(bundleVersion))")
+                    .foregroundStyle(.secondary)
+            } else {
+                Text(verbatim: "版本 \(coreVersion)")
+                    .foregroundStyle(.secondary)
+            }
+
+            Text("© MaaAssistantArknights")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(24)
+        .fixedSize()
+    }
+}
+
+struct AboutView_Previews: PreviewProvider {
+    static var previews: some View {
+        AboutContentView()
+    }
+}

--- a/MeoAsstMac/MeoAsstMacApp.swift
+++ b/MeoAsstMac/MeoAsstMacApp.swift
@@ -46,12 +46,20 @@ struct MeoAsstMacApp: App {
             CommandGroup(replacing: .newItem) {
                 OpenLogFileView()
             }
+            CommandGroup(replacing: .appInfo) {
+                AboutView()
+            }
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesView(updater: updaterController.updater)
             }
             SidebarCommands()
             TaskCommands(viewModel: appViewModel)
         }
+
+        Window("关于 MAA", id: "about") {
+            AboutContentView()
+        }
+        .windowResizability(.contentSize)
 
         Settings {
             TabView {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -3370,6 +3370,16 @@
         }
       }
     },
+    "关于 MAA" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MAA 정보"
+          }
+        }
+      }
+    },
     "关卡名" : {
       "localizations" : {
         "ko" : {


### PR DESCRIPTION
## 问题

「关于 MAA」此前使用系统默认 About 面板，版本号取 `CFBundleShortVersionString`。正式发布构建正常（构建时注入真实版本），但本地/自编译构建（工程未设 MARKETING_VERSION）显示的是回退值 `1.0`，与实际核心版本脱节，排查问题时容易被误导。

## 修复

自定义关于窗口（`CommandGroup(replacing: .appInfo)` + `Window(id: "about")`），版本行改取 `AsstGetVersion()`（MaaCore 导出接口）并括注构建号（`CFBundleVersion`）：

- 正式版显示如 `v6.17.4 (991)`；本地 Debug 构建显示 `DEBUG_VERSION (1)`——与 WPF 版行为一致（同场景也显示 DEBUG_VERSION，发布管线注入真实版本号）
- 版本行用 `Text(verbatim:)` 不进本地化词条，仅新增「关于 MAA」一条词条（含 ko）
- 净改动 4 文件

## 验证

- Debug 构建运行时点验：菜单「MAA → 关于 MAA」存在，弹窗版本行显示 `版本 DEBUG_VERSION (1)`（截图）
- BUILD SUCCEEDED（arm64 / Xcode 26.6）

![about-debug](https://raw.githubusercontent.com/zhangweijian97/MaaMacGui/screenshots/about-version-debug-proof.png)

## Sourcery 总结

将默认的 macOS“关于”面板替换为版本感知的“关于 MAA”窗口，准确反映发布版本和自行构建的版本。

新功能：
- 从应用程序菜单中访问自定义的“关于 MAA”窗口，显示核心版本和构建编号。

错误修复：
- 使用 MaaCore 版本，而不是默认的 bundle marketing version，避免自行构建的应用显示误导性的 1.0 版本。

测试：
- 在 Debug 构建中验证“关于”窗口和版本显示，并确认 arm64 构建成功。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the default macOS About panel with a version-aware About MAA window that accurately reflects release and self-built versions.

New Features:
- Add a custom About MAA window accessible from the application menu, showing the core version and build number.

Bug Fixes:
- Use the MaaCore version instead of the default bundle marketing version to prevent self-built applications from displaying a misleading 1.0 version.

Tests:
- Verify the About window and version display in a Debug build and confirm a successful arm64 build.

</details>