### PR TITLE
feat: 任务队列新增自定任务入口

### DIFF
--- a/MeoAsstMac.xcodeproj/project.pbxproj
+++ b/MeoAsstMac.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		83264A3129EBEE3C0074E33A /* InfrastConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83264A3029EBEE3C0074E33A /* InfrastConfiguration.swift */; };
 		83264A3329EBEE680074E33A /* MallConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83264A3229EBEE680074E33A /* MallConfiguration.swift */; };
 		83264A3529EBEE8D0074E33A /* AwardConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83264A3429EBEE8D0074E33A /* AwardConfiguration.swift */; };
+		83C75A112DD9000100000011 /* CustomConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C75A102DD9000100000010 /* CustomConfiguration.swift */; };
+		83C75A212DD9000100000021 /* CustomSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C75A202DD9000100000020 /* CustomSettingsView.swift */; };
 		83264A3B29EC0F2E0074E33A /* LogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83264A3A29EC0F2E0074E33A /* LogView.swift */; };
 		83264A3E29EC22DE0074E33A /* MAAViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83264A3D29EC22DE0074E33A /* MAAViewModel.swift */; };
 		832903A9302C9802008E1DC6 /* URL+contentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832903A8302C9802008E1DC6 /* URL+contentType.swift */; };
@@ -167,6 +169,8 @@
 		83264A3029EBEE3C0074E33A /* InfrastConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfrastConfiguration.swift; sourceTree = "<group>"; };
 		83264A3229EBEE680074E33A /* MallConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MallConfiguration.swift; sourceTree = "<group>"; };
 		83264A3429EBEE8D0074E33A /* AwardConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AwardConfiguration.swift; sourceTree = "<group>"; };
+		83C75A102DD9000100000010 /* CustomConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomConfiguration.swift; sourceTree = "<group>"; };
+		83C75A202DD9000100000020 /* CustomSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSettingsView.swift; sourceTree = "<group>"; };
 		83264A3A29EC0F2E0074E33A /* LogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogView.swift; sourceTree = "<group>"; };
 		83264A3D29EC22DE0074E33A /* MAAViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MAAViewModel.swift; sourceTree = "<group>"; };
 		832903A8302C9802008E1DC6 /* URL+contentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+contentType.swift"; sourceTree = "<group>"; };
@@ -304,6 +308,7 @@
 				8341194F29EC249E00044F45 /* RoguelikeConfiguration.swift */,
 				8341195429EC55C600044F45 /* CopilotConfiguration.swift */,
 				832985AF29EEF483009F7ED5 /* ReclamationConfiguration.swift */,
+				83C75A102DD9000100000010 /* CustomConfiguration.swift */,
 				83782A2A2CFFAF2900A32BDD /* LegacyConfigurations.swift */,
 			);
 			path = "Task Configurations";
@@ -320,6 +325,7 @@
 				83BFABC72AF1D5BA001A79F4 /* AwardSettingsView.swift */,
 				83D3283828F3048E00018D10 /* RoguelikeSettingsView.swift */,
 				83264A2529EBC9C10074E33A /* ReclamationSettingsView.swift */,
+				83C75A202DD9000100000020 /* CustomSettingsView.swift */,
 			);
 			path = "Configuration Views";
 			sourceTree = "<group>";
@@ -637,6 +643,8 @@
 				832985B929EF9D50009F7ED5 /* MAAContent.swift in Sources */,
 				830C3D1E29BC7DE200B13A9F /* CheckForUpdatesView.swift in Sources */,
 				832985B029EEF483009F7ED5 /* ReclamationConfiguration.swift in Sources */,
+				83C75A112DD9000100000011 /* CustomConfiguration.swift in Sources */,
+				83C75A212DD9000100000021 /* CustomSettingsView.swift in Sources */,
 				833786CF28F188D800D39D6F /* MeoAsstMacApp.swift in Sources */,
 				83CFD47129EAACD7000428A1 /* MAATask.swift in Sources */,
 				8347B5AF2CDF925400AEB627 /* URLSession+downloadProgress.swift in Sources */,

--- a/MeoAsstMac/Configuration Views/CustomSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/CustomSettingsView.swift
@@ -30,7 +30,10 @@ struct CustomSettingsView: View {
     }
 
     private var formattedTaskNames: String {
-        "[" + config.parsedTaskNames.map { "\"\($0)\"" }.joined(separator: ", ") + "]"
+        "[" + config.parsedTaskNames.map { n in
+            let escaped = n.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\"")
+            return "\"\(escaped)\""
+        }.joined(separator: ", ") + "]"
     }
 }
 

--- a/MeoAsstMac/Configuration Views/CustomSettingsView.swift
+++ b/MeoAsstMac/Configuration Views/CustomSettingsView.swift
@@ -1,0 +1,41 @@
+//
+//  CustomSettingsView.swift
+//  MAA
+//
+//  Created by zhangweijian on 11/9/2026.
+//
+
+import SwiftUI
+
+struct CustomSettingsView: View {
+    @Binding var config: CustomConfiguration
+
+    var body: some View {
+        Form {
+            TextField(String(localized: "任务名"), text: $config.taskList, axis: .vertical)
+                .lineLimit(3...6)
+
+            if !config.parsedTaskNames.isEmpty {
+                Text(formattedTaskNames)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+
+            Text(String(localized: "以逗号分隔的任务名列表，将执行第一个匹配的任务及其后续链。示例：TaskA, TaskB → 运行 TaskA（若未匹配则尝试 TaskB）"))
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+    }
+
+    private var formattedTaskNames: String {
+        "[" + config.parsedTaskNames.map { "\"\($0)\"" }.joined(separator: ", ") + "]"
+    }
+}
+
+struct CustomSettings_Preview: PreviewProvider {
+    static var previews: some View {
+        CustomSettingsView(config: .constant(.init()))
+    }
+}

--- a/MeoAsstMac/Model/MAATask.swift
+++ b/MeoAsstMac/Model/MAATask.swift
@@ -17,6 +17,7 @@ enum MAATask: Codable, Equatable {
     case award(AwardConfiguration)
     case roguelike(RoguelikeConfiguration)
     case reclamation(ReclamationConfiguration)
+    case custom(CustomConfiguration)
 }
 
 let defaultTaskConfigurations: [any MAATaskConfiguration] = [
@@ -28,6 +29,7 @@ let defaultTaskConfigurations: [any MAATaskConfiguration] = [
     AwardConfiguration(),
     RoguelikeConfiguration(),
     ReclamationConfiguration(),
+    CustomConfiguration(),
     ClosedownConfiguration(),
 ]
 
@@ -65,7 +67,7 @@ extension MAATaskType: Codable, CustomStringConvertible {
         case .OperBox:
             return String(localized: "干员识别")
         case .Custom:
-            return String(localized: "自定义")
+            return String(localized: "自定任务")
         }
     }
 }

--- a/MeoAsstMac/Model/MAAViewModel.swift
+++ b/MeoAsstMac/Model/MAAViewModel.swift
@@ -471,6 +471,11 @@ extension MAAViewModel {
         for task in tasks {
             guard task.enabled else { continue }
 
+            // 自定任务未填写任务名时跳过，避免向核心提交空的任务链
+            if case .custom(let custom) = task.task, custom.parsedTaskNames.isEmpty {
+                continue
+            }
+
             if let coreID = try await handle?.appendTask(task.task) {
                 taskIDMap[coreID] = task.id
             }

--- a/MeoAsstMac/Navigation/TaskDetail.swift
+++ b/MeoAsstMac/Navigation/TaskDetail.swift
@@ -34,6 +34,8 @@ struct TaskDetail: View {
                         RoguelikeSettingsView(config: taskConfigBinding(config, id: id))
                     case .reclamation(let config):
                         ReclamationSettingsView(config: taskConfigBinding(config, id: id))
+                    case .custom(let config):
+                        CustomSettingsView(config: taskConfigBinding(config, id: id))
                     case .closedown(_):
                         EmptyView()
                     }

--- a/MeoAsstMac/Navigation/TasksContent.swift
+++ b/MeoAsstMac/Navigation/TasksContent.swift
@@ -33,6 +33,8 @@ struct TasksContent: View {
                     TaskCell(id: task.id, config: config, enabled: $task.enabled)
                 case .reclamation(let config):
                     TaskCell(id: task.id, config: config, enabled: $task.enabled)
+                case .custom(let config):
+                    TaskCell(id: task.id, config: config, enabled: $task.enabled)
                 }
             }
             .onMove(perform: moveTask)

--- a/MeoAsstMac/Task Configurations/CustomConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/CustomConfiguration.swift
@@ -1,0 +1,58 @@
+//
+//  CustomConfiguration.swift
+//  MAA
+//
+//  Created by zhangweijian on 11/9/2026.
+//
+
+import Foundation
+
+struct CustomTaskParams: Encodable {
+    let task_names: [String]
+}
+
+struct CustomConfiguration: MAATaskConfiguration {
+    var type: MAATaskType { .Custom }
+
+    var taskList: String
+
+    var title: String {
+        type.description
+    }
+
+    var subtitle: String {
+        let names = parsedTaskNames
+        if names.isEmpty {
+            return String(localized: "未填写任务名")
+        }
+        return names.joined(separator: " ")
+    }
+
+    var summary: String { "" }
+
+    var projectedTask: MAATask {
+        .custom(self)
+    }
+
+    /// 解析用户输入的任务名列表，兼容全角/半角逗号与换行分隔（对照 WPF TaskName 的逗号拆分 + Trim + RemoveEmptyEntries）。
+    var parsedTaskNames: [String] {
+        taskList
+            .replacingOccurrences(of: "，", with: ",")
+            .split(whereSeparator: { $0 == "," || $0 == "\n" || $0 == "\r" })
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+    typealias Params = CustomTaskParams
+
+    var params: CustomTaskParams {
+        CustomTaskParams(task_names: parsedTaskNames)
+    }
+}
+
+extension CustomConfiguration {
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.taskList = try container.decodeIfPresent(String.self, forKey: .taskList) ?? ""
+    }
+}

--- a/MeoAsstMac/Task Configurations/CustomConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/CustomConfiguration.swift
@@ -35,10 +35,13 @@ struct CustomConfiguration: MAATaskConfiguration {
     }
 
     /// 解析用户输入的任务名列表，兼容全角/半角逗号与换行分隔（对照 WPF TaskName 的逗号拆分 + Trim + RemoveEmptyEntries）。
+    /// 先归一化换行：Swift 中 "\r\n" 是单个 grapheme cluster，split 谓词按 Character 比较匹配不到，需拆成 "\n" 再进入分隔。
     var parsedTaskNames: [String] {
         taskList
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
             .replacingOccurrences(of: "，", with: ",")
-            .split(whereSeparator: { $0 == "," || $0 == "\n" || $0 == "\r" })
+            .split(whereSeparator: { $0 == "," || $0 == "\n" })
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
     }

--- a/MeoAsstMac/Task Configurations/MAATaskConfiguration.swift
+++ b/MeoAsstMac/Task Configurations/MAATaskConfiguration.swift
@@ -51,6 +51,8 @@ extension MAAHandle {
             return try appendTask(config: config)
         case .reclamation(let config):
             return try appendTask(config: config)
+        case .custom(let config):
+            return try appendTask(config: config)
         }
     }
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -3144,6 +3144,12 @@
             "state" : "translated",
             "value" : "쉼표로 구분된 작업 이름 목록이며, 첫 번째로 일치하는 작업과 그 이후의 체인을 실행합니다. 예시: TaskA, TaskB → TaskA 실행(일치하지 않으면 TaskB 시도)"
           }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comma-separated task names; the first match and its chain runs. Example: TaskA, TaskB → runs TaskA (else TaskB)."
+          }
         }
       }
     },
@@ -3163,6 +3169,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "작업 이름"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Task Name"
           }
         }
       }
@@ -4912,6 +4924,12 @@
             "state" : "translated",
             "value" : "작업 이름 미입력"
           }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No task name entered"
+          }
         }
       }
     },
@@ -5776,6 +5794,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "커스텀 작업"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom Task"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -3137,12 +3137,32 @@
         }
       }
     },
+    "以逗号分隔的任务名列表，将执行第一个匹配的任务及其后续链。示例：TaskA, TaskB → 运行 TaskA（若未匹配则尝试 TaskB）" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "쉼표로 구분된 작업 이름 목록이며, 첫 번째로 일치하는 작업과 그 이후의 체인을 실행합니다. 예시: TaskA, TaskB → TaskA 실행(일치하지 않으면 TaskB 시도)"
+          }
+        }
+      }
+    },
     "任务" : {
       "localizations" : {
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "작업"
+          }
+        }
+      }
+    },
+    "任务名" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 이름"
           }
         }
       }
@@ -4885,6 +4905,16 @@
     "未启用MacPlayTools触控模式" : {
 
     },
+    "未填写任务名" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업 이름 미입력"
+          }
+        }
+      }
+    },
     "未开启屏幕录制权限，请前往“系统设置” > “隐私与安全性” > “录屏与系统录音”允许MAA访问" : {
 
     },
@@ -5736,6 +5766,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "사용자 지정 교대"
+          }
+        }
+      }
+    },
+    "自定任务" : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커스텀 작업"
           }
         }
       }


### PR DESCRIPTION
## 动机

Windows WPF 版有「自定义任务」类型（任务队列选“自定义”，填节点名列表即可跑任意 pipeline 链），Mac 版任务类型里没有——本 PR 补齐 parity，给 pipeline 开发者/高级用户提供“跑任意链”的入口。

## 用法

任务队列添加「自定任务」→ 文本框填任务名（逗号或换行分隔，全角逗号与 Windows 换行自动归一）→ 引擎按 Custom 类型执行 task_names（备选优先级：第一个存在的任务名被选中，执行它及其后续链）。

## 实现

- 任务类型注册 + 配置面板（多行文本框 + 实时预览，对照 WPF formattedTaskNames）
- 空输入防线：解析为空则跳过提交，不阻塞队列
- 自查修复：Swift 中 `"\r\n"` 是单个字符簇，直接 split 匹配不到——粘贴 Windows 行尾多行文本会整块成为单个任务名导致启动失败，已先归一化换行再拆分（边界测试 18/18）
- 本地化：中（源语言）+ 韩 + 英词条补齐

## 附注

WPF 的可选 `params` 附加字段暂未支持，留 follow-up。

任务队列截图（「自定任务」项在默认队列中可见）：

![custom task in queue](https://raw.githubusercontent.com/zhangweijian97/MaaMacGui/screenshots/custom-task-queue.png)

## Sourcery 摘要

通过本地化的自定义任务配置，为 Mac 任务队列启用自定义流水线链。

新功能：
- 添加自定义任务类型，允许用户提供按优先级排列的流水线任务名称列表以供执行。
- 添加自定义任务配置视图，支持多行输入和解析后名称预览。

错误修复：
- 解析自定义任务名称时，规范化 Windows 换行符和全角逗号。
- 跳过空的自定义任务，而不是提交无效的任务链。

增强功能：
- 在任务配置、队列显示、详情视图和核心任务提交流程中注册自定义任务。
- 为中文、韩文和英文添加自定义任务工作流的本地化字符串。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过本地化的自定义任务配置，支持在 Mac 任务队列中执行自定义流水线链。

新功能：
- 向 Mac 任务队列添加自定义任务类型，允许用户提供按优先级排列的流水线任务名称，并运行第一个匹配的任务链。
- 添加支持多行输入的自定义任务配置，并提供解析后的任务名称预览。

错误修复：
- 解析自定义任务名称时，统一处理 Windows 换行符和全角逗号。
- 跳过没有有效任务名称的自定义任务，而不是提交空任务链。

增强功能：
- 在任务配置、队列显示、任务详情和核心任务提交流程中集成自定义任务。

杂项：
- 为自定义任务工作流添加中文、韩文和英文本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable custom pipeline-chain execution in the Mac task queue through a localized custom task configuration.

New Features:
- Add a custom task type to the Mac task queue, allowing users to provide prioritized pipeline task names and run the first matching chain.
- Add custom task configuration with multiline input and a parsed task-name preview.

Bug Fixes:
- Normalize Windows line endings and full-width commas when parsing custom task names.
- Skip custom tasks without valid task names instead of submitting empty task chains.

Enhancements:
- Integrate custom tasks across task configuration, queue display, task details, and core task submission.

Chores:
- Add Chinese, Korean, and English localization strings for the custom task workflow.

</details>

</details>